### PR TITLE
Using local addresses for remote + other features

### DIFF
--- a/media/inject_script.html
+++ b/media/inject_script.html
@@ -1,6 +1,6 @@
 <!-- Script injected by VS Live Preview -->
 <script type="text/javascript" defer>
-	const url = 'ws://localhost:${WS_PORTNUM}';
+	const url = 'ws://127.0.0.1:${WS_PORTNUM}';
 	const connection = new WebSocket(url);
 
 	connection.onerror = (error) => {
@@ -8,6 +8,13 @@
 		console.log(error);
 	};
 
+	connection.onclose = (event) => {
+		console.log("Error occurred.");
+		
+		// Inform the user about the error.
+		console.log(event)
+
+	};
 	connection.onmessage = (event) => handleSocketMessage(event.data);
 
 	window.addEventListener('message', (event) => handleMessage(event), false);

--- a/media/inject_script.html
+++ b/media/inject_script.html
@@ -79,7 +79,7 @@
 
 	function handleLinkClick(linkTarget) {
 		if (linkTarget && linkTarget != '') {
-			if (!linkTarget.startsWith('http://127.0.0.1:')) {
+			if (!linkTarget.startsWith('${HTTP_URL}')) {
 				window.parent.postMessage(
 					{ command: 'open-external-link', text: linkTarget },
 					'*'

--- a/media/inject_script.html
+++ b/media/inject_script.html
@@ -1,6 +1,6 @@
 <!-- Script injected by VS Live Preview -->
 <script type="text/javascript" defer>
-	const url = 'ws://127.0.0.1:${WS_PORTNUM}';
+	const url = '${WS_URL}';
 	const connection = new WebSocket(url);
 
 	connection.onerror = (error) => {

--- a/media/inject_script.html
+++ b/media/inject_script.html
@@ -1,6 +1,7 @@
 <!-- Script injected by VS Live Preview -->
 <script type="text/javascript" defer>
 	const url = '${WS_URL}';
+	const host = '${HTTP_URL}';
 	const connection = new WebSocket(url);
 
 	connection.onerror = (error) => {
@@ -68,18 +69,19 @@
 			{ command: 'update-path', text: JSON.stringify(commandPayload) },
 			'*'
 		);
+		handleLinkHoverEnd();
 
 		var l = document.getElementsByTagName('a');
 		for (var i = 0; i < l.length; i++) {
 			l[i].onclick = (e) => handleLinkClick(e.target.href);
 			l[i].onmouseenter = (e) => handleLinkHoverStart(e.target.href);
-			l[i].onmouseleave = (e) => handleLinkHoverEnd(e.target.href);
+			l[i].onmouseleave = (e) => handleLinkHoverEnd();
 		}
 	}
 
 	function handleLinkClick(linkTarget) {
 		if (linkTarget && linkTarget != '') {
-			if (!linkTarget.startsWith('${HTTP_URL}')) {
+			if (!linkTarget.startsWith(host)) {
 				window.parent.postMessage(
 					{ command: 'open-external-link', text: linkTarget },
 					'*'
@@ -104,7 +106,7 @@
 		);
 	}
 
-	function handleLinkHoverEnd(linkTarget) {
+	function handleLinkHoverEnd() {
 		window.parent.postMessage(
 			{
 				command: 'link-hover-end',

--- a/media/main.js
+++ b/media/main.js
@@ -186,7 +186,6 @@
 					command: 'open-browser',
 					text: message.text,
 				});
-
 				break;
 			}
 			// from child iframe

--- a/media/main.js
+++ b/media/main.js
@@ -173,7 +173,9 @@
 				break;
 			}
 			case 'set-url': {
+				console.log("set-url");
 				msgJSON = JSON.parse(message.text);
+				console.log(msgJSON);
 				setURLBar(msgJSON.fullPath);
 				updateState(msgJSON.pathname);
 				break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "live-server",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -820,12 +820,12 @@
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
 		},
 		"cheerio": {
-			"version": "1.0.0-rc.9",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.9.tgz",
-			"integrity": "sha512-QF6XVdrLONO6DXRF5iaolY+odmhj2CLj+xzNod7INPWMi/x9X4SOylH0S/vaPpX+AUU6t04s34SQNh7DbkuCng==",
+			"version": "1.0.0-rc.10",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+			"integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
 			"requires": {
-				"cheerio-select": "^1.4.0",
-				"dom-serializer": "^1.3.1",
+				"cheerio-select": "^1.5.0",
+				"dom-serializer": "^1.3.2",
 				"domhandler": "^4.2.0",
 				"htmlparser2": "^6.1.0",
 				"parse5": "^6.0.1",
@@ -834,22 +834,22 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-					"integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+					"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
 				}
 			}
 		},
 		"cheerio-select": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.4.0.tgz",
-			"integrity": "sha512-sobR3Yqz27L553Qa7cK6rtJlMDbiKPdNywtR95Sj/YgfpLfy0u6CGJuaBKe5YE/vTc23SCRKxWSdlon/w6I/Ew==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
+			"integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
 			"requires": {
-				"css-select": "^4.1.2",
-				"css-what": "^5.0.0",
+				"css-select": "^4.1.3",
+				"css-what": "^5.0.1",
 				"domelementtype": "^2.2.0",
 				"domhandler": "^4.2.0",
-				"domutils": "^2.6.0"
+				"domutils": "^2.7.0"
 			}
 		},
 		"chrome-trace-event": {
@@ -1043,9 +1043,9 @@
 			}
 		},
 		"css-select": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.2.tgz",
-			"integrity": "sha512-nu5ye2Hg/4ISq4XqdLY2bEatAcLIdt3OYGFc9Tm9n7VSlFBcfRv0gBNksHRgSdUDQGtN3XrZ94ztW+NfzkFSUw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+			"integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
 			"requires": {
 				"boolbase": "^1.0.0",
 				"css-what": "^5.0.0",
@@ -1198,9 +1198,9 @@
 			}
 		},
 		"domutils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-			"integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+			"integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
 			"requires": {
 				"dom-serializer": "^1.0.1",
 				"domelementtype": "^2.2.0",
@@ -3585,9 +3585,9 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
 		},
 		"vsce": {
-			"version": "1.91.0",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.91.0.tgz",
-			"integrity": "sha512-y75QryWKzAw5KIR4NFEXc6XAy/Er1BHXdNwAESgKKFw8Yc8cA/+dP4Gj7VYhNPOJlV0v5j1in/cPkLFZAqC7cQ==",
+			"version": "1.95.0",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.95.0.tgz",
+			"integrity": "sha512-OiSrJRd9NT4t+MBVrTblHqo0pOGaoplHzEzSNOGnIsLxyRIqk4CYmoqUnjOrZf8DEalbALsFVTFbTJLeC1hAKA==",
 			"requires": {
 				"azure-devops-node-api": "^10.2.2",
 				"chalk": "^2.4.2",
@@ -3604,7 +3604,7 @@
 				"parse-semver": "^1.1.1",
 				"read": "^1.0.7",
 				"semver": "^5.1.0",
-				"tmp": "0.0.29",
+				"tmp": "^0.2.1",
 				"typed-rest-client": "^1.8.4",
 				"url-join": "^1.1.0",
 				"yauzl": "^2.3.1",
@@ -3637,11 +3637,11 @@
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				},
 				"tmp": {
-					"version": "0.0.29",
-					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-					"integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+					"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
 					"requires": {
-						"os-tmpdir": "~1.0.1"
+						"rimraf": "^3.0.0"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "live-server",
 	"displayName": "Live Preview",
 	"description": "Hosts a local server in your workspace for you to preview your webpages.",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"preview": true,
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
 	"publisher": "ms-vscode",

--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
 		"prettier-eslint": "^12.0.0",
 		"prettier-eslint-cli": "^5.0.1",
 		"url": "^0.11.0",
-		"vsce": "^1.91.0",
+		"vsce": "^1.95.0",
 		"vscode-codicons": "0.0.17",
 		"vscode-extension-telemetry": "^0.1.7",
 		"ws": "^7.4.6"

--- a/package.json
+++ b/package.json
@@ -200,6 +200,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Whether or not to warn the user upon opening a multi-root preview with an undefined default server workspace."
+				},
+				"LivePreview.runTaskWithExternalPreview": {
+					"type": "boolean",
+					"default": true,
+					"description": "Whether or not to pair external preview instances with the Live Preview task. When disabled, the embedded preview closing will not cause the server to close to prevent suddent server disconnection."
 				}
 			}
 		},

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -30,7 +30,6 @@ export class BrowserPreview extends Disposable {
 	}
 
 	public reveal(column: number, file = '/'): void {
-		console.log(`reveal ${file}`);
 		this.goToFile(file);
 		this.handleNewPageLoad(file);
 		this._panel.reveal(column);
@@ -118,15 +117,7 @@ export class BrowserPreview extends Disposable {
 						this.handleOpenBrowser(message.text);
 						return;
 					case 'add-history': {
-						this._panel.webview.postMessage({
-							command: 'set-url',
-							text: JSON.stringify({
-								fullPath: this.constructAddress(message.text),
-								pathname: message.text,
-							}),
-						});
-						// called from main.js in the case where the target is non-injectable
-						this.handleNewPageLoad(message.text);
+						this.setUrlBar(message.text);
 						return;
 					}
 					case 'refresh-back-forward-buttons':
@@ -143,6 +134,18 @@ export class BrowserPreview extends Disposable {
 	dispose() {
 		this._onDisposeEmitter.fire();
 		super.dispose();
+	}
+
+	private async setUrlBar(pathname: string) {
+		this._panel.webview.postMessage({
+			command: 'set-url',
+			text: JSON.stringify({
+				fullPath: await this.constructAddress(pathname),
+				pathname: pathname,
+			}),
+		});
+		// called from main.js in the case where the target is non-injectable
+		this.handleNewPageLoad(pathname);
 	}
 
 	public get panel() {

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -30,6 +30,7 @@ export class BrowserPreview extends Disposable {
 	}
 
 	public reveal(column: number, file = '/'): void {
+		console.log(`reveal ${file}`);
 		this.goToFile(file);
 		this.handleNewPageLoad(file);
 		this._panel.reveal(column);
@@ -212,7 +213,10 @@ export class BrowserPreview extends Disposable {
 		}
 	}
 
-	private async constructAddress(URLExt: string, hostURI?: vscode.Uri): Promise<string> {
+	private async constructAddress(
+		URLExt: string,
+		hostURI?: vscode.Uri
+	): Promise<string> {
 		if (URLExt.length > 0 && URLExt[0] == '/') {
 			URLExt = URLExt.substring(1);
 		}
@@ -225,13 +229,17 @@ export class BrowserPreview extends Disposable {
 		return `${hostURI.toString()}${URLExt}`;
 	}
 
-	private async setHtml(webview: vscode.Webview, url: string, httpHost: vscode.Uri) {
+	private async setHtml(
+		webview: vscode.Webview,
+		url: string,
+		httpHost: vscode.Uri
+	) {
 		const wsURI = await this.resolveWsHost();
 		this._panel.webview.html = this.getHtmlForWebview(
 			webview,
 			url,
 			`ws://${wsURI.authority}`,
-			`${httpHost.scheme}://${httpHost.authority}`,
+			`${httpHost.scheme}://${httpHost.authority}`
 		);
 	}
 

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { HOST, INIT_PANEL_TITLE, OPEN_EXTERNALLY } from '../utils/constants';
+import { INIT_PANEL_TITLE, OPEN_EXTERNALLY } from '../utils/constants';
 import { Disposable } from '../utils/dispose';
 import { isFileInjectable } from '../utils/utils';
 import { PathUtil } from '../utils/pathUtil';
@@ -162,7 +162,11 @@ export class BrowserPreview extends Disposable {
 
 	private async goToFullAddress(address: string) {
 		const host = await this.resolveHost();
-		if (address.startsWith(host.toString())) {
+		let hostString = host.toString();
+		if (hostString.endsWith('/')) {
+			hostString = hostString.substr(0, hostString.length - 1);
+		}
+		if (address.startsWith(hostString)) {
 			const file = address.substr(host.toString().length);
 			this.goToFile(file);
 			this.handleNewPageLoad(file);

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -213,25 +213,30 @@ export class BrowserPreview extends Disposable {
 	}
 
 	private async constructAddress(URLExt: string): Promise<string> {
-		this._connectionManager.resolveExternalHTTPUri().then((uri)=> {
-
-		})
 		if (URLExt.length > 0 && URLExt[0] == '/') {
 			URLExt = URLExt.substring(1);
 		}
 		URLExt = URLExt.replace('\\', '/');
 		URLExt = URLExt.startsWith('/') ? URLExt.substr(1) : URLExt;
-		
+
 		const hostUri = await this.resolveHost();
-		return `${hostUri.toString()}/${URLExt}`;
+		return `${hostUri.toString()}${URLExt}`;
 	}
 
 	private async setHtml(webview: vscode.Webview, url: string) {
 		const wsURI = await this.resolveWsHost();
-		this._panel.webview.html = this.getHtmlForWebview(webview, url, `ws://${wsURI.authority}`);
+		this._panel.webview.html = this.getHtmlForWebview(
+			webview,
+			url,
+			`ws://${wsURI.authority}`
+		);
 	}
 
-	private getHtmlForWebview(webview: vscode.Webview, httpURL: string, wsURL: string): string {
+	private getHtmlForWebview(
+		webview: vscode.Webview,
+		httpURL: string,
+		wsURL: string
+	): string {
 		// Local path to main script run in the webview
 		const scriptPathOnDisk = vscode.Uri.joinPath(
 			this._extensionUri,
@@ -260,7 +265,6 @@ export class BrowserPreview extends Disposable {
 
 		// Use a nonce to only allow specific scripts to be run
 		const nonce = new Date().getTime() + '' + new Date().getMilliseconds();
-
 
 		return `<!DOCTYPE html>
 		<html lang="en">

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -249,7 +249,7 @@ export class BrowserPreview extends Disposable {
 		// Use a nonce to only allow specific scripts to be run
 		const nonce = new Date().getTime() + '' + new Date().getMilliseconds();
 
-		const wsURL = `ws://localhost:${this._wsPort}`;
+		const wsURL = `ws://${HOST}:${this._wsPort}`;
 		return `<!DOCTYPE html>
 		<html lang="en">
 			<head>

--- a/src/editorPreview/pageHistoryTracker.ts
+++ b/src/editorPreview/pageHistoryTracker.ts
@@ -81,11 +81,17 @@ export class PageHistory extends Disposable {
 
 	public addHistory(address: string): NavResponse | undefined {
 		address = address.replace(/\\/g, '/');
+
 		const action = new Array<NavEditCommands>();
 		if (
 			this._backstep < this._history.length &&
-			address == this._history[this._backstep]
+			(address == this._history[this._backstep] ||
+				(address.endsWith('/') &&
+					address.substr(0, address.length - 1) ==
+						this._history[this._backstep]))
 		) {
+			// if this is the same as the last entry or is a
+			// redirect of the previous, don't add to history
 			return undefined;
 		}
 		if (this._backstep > 0) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,6 @@ let reporter: TelemetryReporter;
 let manager: Manager;
 
 export function activate(context: vscode.ExtensionContext) {
-	console.log('ACTIVATE');
 	const extPackageJSON = context.extension.packageJSON;
 
 	reporter = new TelemetryReporter(
@@ -225,5 +224,4 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate(): void {
 	reporter.dispose();
 	manager.dispose();
-	console.log('DEACTIVATE');
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ let reporter: TelemetryReporter;
 let manager: Manager;
 
 export function activate(context: vscode.ExtensionContext) {
-	console.log("ACTIVATE");
+	console.log('ACTIVATE');
 	const extPackageJSON = context.extension.packageJSON;
 
 	reporter = new TelemetryReporter(
@@ -225,5 +225,5 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate(): void {
 	reporter.dispose();
 	manager.dispose();
-	console.log("DEACTIVATE");
+	console.log('DEACTIVATE');
 }

--- a/src/infoManagers/connectionManager.ts
+++ b/src/infoManagers/connectionManager.ts
@@ -5,7 +5,15 @@ export interface PortInfo {
 	port: number;
 	ws_port: number;
 }
+
+export interface ConnectionInfo {
+	httpURI: vscode.Uri;
+	wsURI: vscode.Uri;
+}
+
 export class ConnectionManager extends Disposable {
+	public httpServerBase: string | undefined;
+	public wsServerBase: string | undefined;
 	public _wsPort: number;
 	public _httpPort: number;
 	private _initHttpPort;
@@ -28,13 +36,25 @@ export class ConnectionManager extends Disposable {
 		this._wsPort = this._initWSPort;
 	}
 
+	private constructLocalUri(port: number) {
+		return vscode.Uri.parse(`http://${HOST}:${port}`)
+	}
+
 	public connected(ports: PortInfo) {
 		this._httpPort = ports.port;
 		this._wsPort = ports.ws_port;
-		this._onConnected.fire(ports);
-		vscode.env.asExternalUri(vscode.Uri.parse(`http://${HOST}/${this._httpPort}`)).then((value) => console.log(value));
-		vscode.env.asExternalUri(vscode.Uri.parse(`http://${HOST}/${this._wsPort}`)).then((value) => console.log(value));
+		
+		const httpPortUri = this.constructLocalUri(this._httpPort);
+		const wsPortUri = this.constructLocalUri(this._wsPort);
+
+		vscode.env.asExternalUri(httpPortUri).then((externalHTTPUri) => {
+			vscode.env.asExternalUri(wsPortUri).then((externalWSUri) => {
+				this._onConnected.fire({httpURI: externalHTTPUri, wsURI: externalWSUri});
+			});
+		});
 	}
+
+
 
 	public disconnected() {
 		this._httpPort = this._initHttpPort;
@@ -47,7 +67,17 @@ export class ConnectionManager extends Disposable {
 	}
 
 	private readonly _onConnected = this._register(
-		new vscode.EventEmitter<PortInfo>()
+		new vscode.EventEmitter<ConnectionInfo>()
 	);
 	public readonly onConnected = this._onConnected.event;
+
+	public async resolveExternalHTTPUri(): Promise<vscode.Uri> {
+		const httpPortUri = this.constructLocalUri(this._httpPort);
+		return await vscode.env.asExternalUri(httpPortUri)
+	}
+
+	public async resolveExternalWSUri(): Promise<vscode.Uri> {
+		const wsPortUri = this.constructLocalUri(this._wsPort);
+		return await vscode.env.asExternalUri(wsPortUri)
+	}
 }

--- a/src/infoManagers/connectionManager.ts
+++ b/src/infoManagers/connectionManager.ts
@@ -37,24 +37,25 @@ export class ConnectionManager extends Disposable {
 	}
 
 	private constructLocalUri(port: number) {
-		return vscode.Uri.parse(`http://${HOST}:${port}`)
+		return vscode.Uri.parse(`http://${HOST}:${port}`);
 	}
 
 	public connected(ports: PortInfo) {
 		this._httpPort = ports.port;
 		this._wsPort = ports.ws_port;
-		
+
 		const httpPortUri = this.constructLocalUri(this._httpPort);
 		const wsPortUri = this.constructLocalUri(this._wsPort);
 
 		vscode.env.asExternalUri(httpPortUri).then((externalHTTPUri) => {
 			vscode.env.asExternalUri(wsPortUri).then((externalWSUri) => {
-				this._onConnected.fire({httpURI: externalHTTPUri, wsURI: externalWSUri});
+				this._onConnected.fire({
+					httpURI: externalHTTPUri,
+					wsURI: externalWSUri,
+				});
 			});
 		});
 	}
-
-
 
 	public disconnected() {
 		this._httpPort = this._initHttpPort;
@@ -73,11 +74,11 @@ export class ConnectionManager extends Disposable {
 
 	public async resolveExternalHTTPUri(): Promise<vscode.Uri> {
 		const httpPortUri = this.constructLocalUri(this._httpPort);
-		return await vscode.env.asExternalUri(httpPortUri)
+		return await vscode.env.asExternalUri(httpPortUri);
 	}
 
 	public async resolveExternalWSUri(): Promise<vscode.Uri> {
 		const wsPortUri = this.constructLocalUri(this._wsPort);
-		return await vscode.env.asExternalUri(wsPortUri)
+		return await vscode.env.asExternalUri(wsPortUri);
 	}
 }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -234,7 +234,7 @@ export class Manager extends Disposable {
 					uri,
 					ServerStartedStatus.STARTED_BY_EMBEDDED_PREV
 				);
-			})
+			});
 		}
 
 		return true;

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -131,7 +131,7 @@ export class Manager extends Disposable {
 						this._pendingLaunchInfo.file,
 						this._pendingLaunchInfo.relative,
 						this._pendingLaunchInfo.panel
-					)
+					);
 				}
 				this._pendingLaunchInfo = undefined;
 			}
@@ -171,23 +171,22 @@ export class Manager extends Disposable {
 	): void {
 		if (!this._server.isRunning) {
 			this._pendingLaunchInfo = {
-				external:false,
+				external: false,
 				panel: panel,
 				file: file,
 				relative: relative,
-			}
+			};
 			this.openServer();
 		} else {
-			this.launchFileInEmbeddedPreview(file,relative,panel);
+			this.launchFileInEmbeddedPreview(file, relative, panel);
 		}
-
 	}
 
 	public showPreviewInBrowser(file = '/', relative = true) {
 		if (!this._serverTaskProvider.isRunning) {
 			if (!this._server.isRunning) {
 				this._pendingLaunchInfo = {
-					external:true,
+					external: true,
 					file: file,
 					relative: relative,
 				};
@@ -277,16 +276,15 @@ export class Manager extends Disposable {
 	private launchFileInEmbeddedPreview(
 		file: string,
 		relative: boolean,
-		panel: vscode.WebviewPanel | undefined,
-		) {
-
+		panel: vscode.WebviewPanel | undefined
+	) {
 		file = this.transformNonRelativeFile(relative, file);
 		// If we already have a panel, show it.
 		if (this.currentPanel) {
 			this.currentPanel.reveal(vscode.ViewColumn.Beside, file);
 			return;
 		}
-		
+
 		if (!panel) {
 			// Otherwise, create a new panel.
 			panel = vscode.window.createWebviewPanel(
@@ -302,7 +300,7 @@ export class Manager extends Disposable {
 
 		this.startEmbeddedPreview(panel, file);
 	}
-	
+
 	private transformNonRelativeFile(relative: boolean, file: string): string {
 		if (!relative) {
 			if (!this._workspaceManager.canGetPath(file)) {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -113,7 +113,7 @@ export class Manager extends Disposable {
 
 		this._connectionManager.onConnected((e) => {
 			this._serverTaskProvider.serverStarted(
-				e.port,
+				e.httpURI,
 				ServerStartedStatus.JUST_STARTED
 			);
 
@@ -229,10 +229,12 @@ export class Manager extends Disposable {
 		if (!this._server.isRunning) {
 			return this._server.openServer(this._serverPort);
 		} else if (fromTask) {
-			this._serverTaskProvider.serverStarted(
-				this._serverPort,
-				ServerStartedStatus.STARTED_BY_EMBEDDED_PREV
-			);
+			this._connectionManager.resolveExternalHTTPUri().then((uri) => {
+				this._serverTaskProvider.serverStarted(
+					uri,
+					ServerStartedStatus.STARTED_BY_EMBEDDED_PREV
+				);
+			})
 		}
 
 		return true;
@@ -273,6 +275,7 @@ export class Manager extends Disposable {
 		const uri = vscode.Uri.parse(
 			`http://${HOST}:${this._serverPort}${relFile}`
 		);
+		// will already resolve to local address
 		vscode.env.openExternal(uri);
 	}
 	private transformNonRelativeFile(relative: boolean, file: string): string {

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -7,7 +7,6 @@ import { ContentLoader } from './serverUtils/contentLoader';
 import { HTMLInjector } from './serverUtils/HTMLInjector';
 import { HOST } from '../utils/constants';
 import { serverMsg } from '../manager';
-import { isFileInjectable } from '../utils/utils';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { EndpointManager } from '../infoManagers/endpointManager';
 import { WorkspaceManager } from '../infoManagers/workspaceManager';
@@ -57,14 +56,14 @@ export class HttpServer extends Disposable {
 		this._server.close();
 	}
 
-	public set injectorWSPort(ws_port: number) {
+	public set injectorWSUri(wsURI: vscode.Uri) {
 		if (!this._contentLoader.scriptInjector) {
 			this._contentLoader.scriptInjector = new HTMLInjector(
 				this._extensionUri,
-				ws_port
+				wsURI
 			);
 		} else if (this._contentLoader.scriptInjector) {
-			this._contentLoader.scriptInjector.ws_port = ws_port;
+			this._contentLoader.scriptInjector.wsURI = wsURI;
 		}
 	}
 

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -10,6 +10,7 @@ import { serverMsg } from '../manager';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { EndpointManager } from '../infoManagers/endpointManager';
 import { WorkspaceManager } from '../infoManagers/workspaceManager';
+import { ConnectionManager } from '../infoManagers/connectionManager';
 
 export class HttpServer extends Disposable {
 	private _server: any;
@@ -21,7 +22,8 @@ export class HttpServer extends Disposable {
 		extensionUri: vscode.Uri,
 		private readonly _reporter: TelemetryReporter,
 		private readonly _endpointManager: EndpointManager,
-		private readonly _workspaceManager: WorkspaceManager
+		private readonly _workspaceManager: WorkspaceManager,
+		private readonly _connectionManager: ConnectionManager
 	) {
 		super();
 		this._contentLoader = this._register(new ContentLoader(_reporter));
@@ -56,14 +58,14 @@ export class HttpServer extends Disposable {
 		this._server.close();
 	}
 
-	public set injectorWSUri(wsURI: vscode.Uri) {
+	public refreshInjector() {
 		if (!this._contentLoader.scriptInjector) {
 			this._contentLoader.scriptInjector = new HTMLInjector(
 				this._extensionUri,
-				wsURI
+				this._connectionManager
 			);
-		} else if (this._contentLoader.scriptInjector) {
-			this._contentLoader.scriptInjector.wsURI = wsURI;
+		} else {
+			this._contentLoader.scriptInjector.refresh();
 		}
 	}
 

--- a/src/server/serverManager.ts
+++ b/src/server/serverManager.ts
@@ -110,6 +110,12 @@ export class Server extends Disposable {
 			})
 		);
 
+		this._register(
+			this._connectionManager.onConnected((e) => {
+				this._httpServer.injectorWSUri = e.wsURI;
+			})
+		)
+
 		vscode.commands.executeCommand('setContext', 'LivePreviewServerOn', false);
 	}
 
@@ -189,8 +195,6 @@ export class Server extends Disposable {
 		this._isServerOn = true;
 		this._statusBar.ServerOn(this._httpServer.port);
 
-		this._httpServer.injectorWSPort = this._wsServer.ws_port;
-		this._wsServer.hostName = `http://${HOST}:${this._httpServer.port}`;
 		this.showServerStatusMessage(
 			`Server Opened on Port ${this._httpServer.port}`
 		);
@@ -198,6 +202,9 @@ export class Server extends Disposable {
 			port: this._httpServer.port,
 			ws_port: this._wsServer.ws_port,
 		});
+		this._connectionManager.resolveExternalHTTPUri().then((uri) => {
+			this._wsServer.externalHostName = uri.toString();
+		})
 		vscode.commands.executeCommand('setContext', 'LivePreviewServerOn', true);
 	}
 

--- a/src/server/serverUtils/HTMLInjector.ts
+++ b/src/server/serverUtils/HTMLInjector.ts
@@ -1,34 +1,64 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { WS_PORTNUM_PLACEHOLDER } from '../../utils/constants';
+import { ConnectionManager } from '../../infoManagers/connectionManager';
+import {
+	HTTP_URL_PLACEHOLDER,
+	WS_URL_PLACEHOLDER,
+} from '../../utils/constants';
 import { Disposable } from '../../utils/dispose';
 
+interface replaceObj {
+	original: string;
+	replacement: string;
+}
 export class HTMLInjector extends Disposable {
-	private readonly _pre_port_script: string;
-	private readonly _post_port_script: string;
-	public wsURL: string;
+	public script: string | undefined;
+	public rawScript: string;
 
-	constructor(extensionUri: vscode.Uri, wsUri: vscode.Uri) {
+	constructor(
+		extensionUri: vscode.Uri,
+		private readonly _connectionManager: ConnectionManager
+	) {
 		super();
 		const scriptPath = path.join(
 			extensionUri.fsPath,
 			'media',
 			'inject_script.html'
 		);
-		this.wsURL = `ws://${wsUri.authority}`;
-		const fileString = fs.readFileSync(scriptPath, 'utf8').toString();
-		const placeHolderIndex = fileString.indexOf(WS_PORTNUM_PLACEHOLDER);
-		this._pre_port_script = fileString.substr(0, placeHolderIndex);
-		this._post_port_script = fileString.substr(
-			placeHolderIndex + WS_PORTNUM_PLACEHOLDER.length
-		);
+		this.rawScript = fs.readFileSync(scriptPath, 'utf8').toString();
+		this.initScript(this.rawScript);
 	}
 
-	public set wsURI(uri: vscode.Uri) {
-		this.wsURL = `ws://${uri.authority}`;
-	} 
-	public get script() {
-		return this._pre_port_script + this.wsURL + this._post_port_script;
+	private async initScript(fileString: string) {
+		const httpUri = await this._connectionManager.resolveExternalHTTPUri();
+		const wsUri = await this._connectionManager.resolveExternalWSUri();
+		const wsURL = `ws://${wsUri.authority}`;
+		let httpURL = `${httpUri.scheme}://${httpUri.authority}`;
+
+		if (httpURL.endsWith('/')) {
+			httpURL = httpURL.substr(httpURL.length - 1);
+		}
+		const replacements = [
+			{ original: WS_URL_PLACEHOLDER, replacement: wsURL },
+			{ original: HTTP_URL_PLACEHOLDER, replacement: httpURL },
+		];
+		this.script = this.replace(fileString, replacements);
+	}
+
+	private replace(script: string, replaces: replaceObj[]): string {
+		for (const i in replaces) {
+			const replace = replaces[i];
+			const placeHolderIndex = script.indexOf(replace.original);
+			script =
+				script.substr(0, placeHolderIndex) +
+				replace.replacement +
+				script.substr(placeHolderIndex + replace.original.length);
+		}
+		return script;
+	}
+
+	public refresh() {
+		this.initScript(this.rawScript);
 	}
 }

--- a/src/server/serverUtils/HTMLInjector.ts
+++ b/src/server/serverUtils/HTMLInjector.ts
@@ -7,16 +7,16 @@ import { Disposable } from '../../utils/dispose';
 export class HTMLInjector extends Disposable {
 	private readonly _pre_port_script: string;
 	private readonly _post_port_script: string;
-	public ws_port;
+	public wsURL: string;
 
-	constructor(extensionUri: vscode.Uri, ws_port: number) {
+	constructor(extensionUri: vscode.Uri, wsUri: vscode.Uri) {
 		super();
 		const scriptPath = path.join(
 			extensionUri.fsPath,
 			'media',
 			'inject_script.html'
 		);
-		this.ws_port = ws_port;
+		this.wsURL = `ws://${wsUri.authority}`;
 		const fileString = fs.readFileSync(scriptPath, 'utf8').toString();
 		const placeHolderIndex = fileString.indexOf(WS_PORTNUM_PLACEHOLDER);
 		this._pre_port_script = fileString.substr(0, placeHolderIndex);
@@ -25,7 +25,10 @@ export class HTMLInjector extends Disposable {
 		);
 	}
 
+	public set wsURI(uri: vscode.Uri) {
+		this.wsURL = `ws://${uri.authority}`;
+	} 
 	public get script() {
-		return this._pre_port_script + this.ws_port + this._post_port_script;
+		return this._pre_port_script + this.wsURL + this._post_port_script;
 	}
 }

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -16,12 +16,11 @@ export class WSServerWithOriginCheck extends WebSocket.Server {
 
 	shouldHandle(req: http.IncomingMessage): boolean {
 		const origin = req.headers['origin'];
-		console.log(origin);
-		// return <boolean>(
-		// 	(origin &&
-		// 		(origin.startsWith(VSCODE_WEBVIEW) ||
-		// 			(this.externalHostName && origin == this.externalHostName)))
-		// );
+		return <boolean>(
+			(origin &&
+				(origin.startsWith(VSCODE_WEBVIEW) ||
+					(this.externalHostName && origin == this.externalHostName)))
+		);
 		return true;
 	}
 }

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -12,14 +12,14 @@ import { WorkspaceManager } from '../infoManagers/workspaceManager';
 import { HOST, VSCODE_WEBVIEW } from '../utils/constants';
 
 export class WSServerWithOriginCheck extends WebSocket.Server {
-	public hostName: string | undefined;
+	public externalHostName: string | undefined;
 
 	shouldHandle(req: http.IncomingMessage): boolean {
 		const origin = req.headers['origin'];
 		return <boolean>(
 			(origin &&
 				(origin.startsWith(VSCODE_WEBVIEW) ||
-					(this.hostName && origin == this.hostName)))
+					(this.externalHostName && origin == this.externalHostName)))
 		);
 	}
 }
@@ -28,9 +28,9 @@ export class WSServer extends Disposable {
 	private _wss: WSServerWithOriginCheck | undefined;
 	private _ws_port = 0;
 
-	public set hostName(hostName: string) {
+	public set externalHostName(hostName: string) {
 		if (this._wss) {
-			this._wss.hostName = hostName;
+			this._wss.externalHostName = hostName;
 		}
 	}
 

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -9,7 +9,7 @@ import { isFileInjectable } from '../utils/utils';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { EndpointManager } from '../infoManagers/endpointManager';
 import { WorkspaceManager } from '../infoManagers/workspaceManager';
-import { VSCODE_WEBVIEW } from '../utils/constants';
+import { HOST, VSCODE_WEBVIEW } from '../utils/constants';
 
 export class WSServerWithOriginCheck extends WebSocket.Server {
 	public hostName: string | undefined;
@@ -71,7 +71,7 @@ export class WSServer extends Disposable {
 	}
 
 	private startWSServer(basePath: string): boolean {
-		this._wss = new WSServerWithOriginCheck({ port: this._ws_port });
+		this._wss = new WSServerWithOriginCheck({ port: this._ws_port, host: HOST });
 		this._wss.on('connection', (ws: WebSocket) =>
 			this.handleWSConnection(basePath, ws)
 		);

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -71,7 +71,10 @@ export class WSServer extends Disposable {
 	}
 
 	private startWSServer(basePath: string): boolean {
-		this._wss = new WSServerWithOriginCheck({ port: this._ws_port, host: HOST });
+		this._wss = new WSServerWithOriginCheck({
+			port: this._ws_port,
+			host: HOST,
+		});
 		this._wss.on('connection', (ws: WebSocket) =>
 			this.handleWSConnection(basePath, ws)
 		);

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -16,11 +16,13 @@ export class WSServerWithOriginCheck extends WebSocket.Server {
 
 	shouldHandle(req: http.IncomingMessage): boolean {
 		const origin = req.headers['origin'];
-		return <boolean>(
-			(origin &&
-				(origin.startsWith(VSCODE_WEBVIEW) ||
-					(this.externalHostName && origin == this.externalHostName)))
-		);
+		console.log(origin);
+		// return <boolean>(
+		// 	(origin &&
+		// 		(origin.startsWith(VSCODE_WEBVIEW) ||
+		// 			(this.externalHostName && origin == this.externalHostName)))
+		// );
+		return true;
 	}
 }
 

--- a/src/task/serverTaskProvider.ts
+++ b/src/task/serverTaskProvider.ts
@@ -84,9 +84,9 @@ export class ServerTaskProvider
 		}
 	}
 
-	public serverStarted(port: number, status: ServerStartedStatus) {
+	public serverStarted(externalUri: vscode.Uri, status: ServerStartedStatus) {
 		if (this._terminal && this._terminal.running) {
-			this._terminal.serverStarted(port, status);
+			this._terminal.serverStarted(externalUri, status);
 		}
 	}
 

--- a/src/task/serverTaskTerminal.ts
+++ b/src/task/serverTaskTerminal.ts
@@ -60,15 +60,17 @@ export class ServerTaskTerminal
 	}
 
 	private formatAddr(addr: string) {
-		const indexOfColon = addr.lastIndexOf(":");
+		const indexOfColon = addr.lastIndexOf(':');
+		const firstHalfOfString = addr.substr(0, indexOfColon);
+		const lastHalfOfString = addr.substr(indexOfColon);
 		return (
 			this.colorTerminalString(
-				addr.substr(indexOfColon),
+				firstHalfOfString,
 				TerminalColor.blue,
 				TerminalDeco.bold
 			) +
 			this.colorTerminalString(
-				addr.substr(indexOfColon,addr.length),
+				lastHalfOfString,
 				TerminalColor.purple,
 				TerminalDeco.bold
 			)
@@ -79,9 +81,7 @@ export class ServerTaskTerminal
 		const formattedAddress = this.formatAddr(externalUri.toString());
 		switch (status) {
 			case ServerStartedStatus.JUST_STARTED: {
-				this.writeEmitter.fire(
-					`Started Server on ${formattedAddress}\r\n`
-				);
+				this.writeEmitter.fire(`Started Server on ${formattedAddress}\r\n`);
 				break;
 			}
 			case ServerStartedStatus.STARTED_BY_EMBEDDED_PREV: {

--- a/src/task/serverTaskTerminal.ts
+++ b/src/task/serverTaskTerminal.ts
@@ -59,32 +59,34 @@ export class ServerTaskTerminal
 		}
 	}
 
-	private formatAddr(port: number) {
+	private formatAddr(addr: string) {
+		const indexOfColon = addr.lastIndexOf(":");
 		return (
 			this.colorTerminalString(
-				`http://${HOST}`,
+				addr.substr(indexOfColon),
 				TerminalColor.blue,
 				TerminalDeco.bold
 			) +
 			this.colorTerminalString(
-				`:${port}`,
+				addr.substr(indexOfColon,addr.length),
 				TerminalColor.purple,
 				TerminalDeco.bold
 			)
 		);
 	}
 
-	public serverStarted(port: number, status: ServerStartedStatus) {
+	public serverStarted(externalUri: vscode.Uri, status: ServerStartedStatus) {
+		const formattedAddress = this.formatAddr(externalUri.toString());
 		switch (status) {
 			case ServerStartedStatus.JUST_STARTED: {
 				this.writeEmitter.fire(
-					`Started Server on ${this.formatAddr(port)}\r\n`
+					`Started Server on ${formattedAddress}\r\n`
 				);
 				break;
 			}
 			case ServerStartedStatus.STARTED_BY_EMBEDDED_PREV: {
 				this.writeEmitter.fire(
-					`Server already on at ${this.formatAddr(port)}\r\n> `
+					`Server already on at ${formattedAddress}\r\n> `
 				);
 				break;
 			}

--- a/src/task/serverTaskTerminal.ts
+++ b/src/task/serverTaskTerminal.ts
@@ -65,8 +65,8 @@ export class ServerTaskTerminal
 			return str.length;
 		}
 
-		const indexSecondColon = str.indexOf(':',indexColon+1);
-		return (indexSecondColon == -1) ? str.length : indexSecondColon;
+		const indexSecondColon = str.indexOf(':', indexColon + 1);
+		return indexSecondColon == -1 ? str.length : indexSecondColon;
 	}
 
 	private formatAddr(addr: string) {

--- a/src/task/serverTaskTerminal.ts
+++ b/src/task/serverTaskTerminal.ts
@@ -59,10 +59,20 @@ export class ServerTaskTerminal
 		}
 	}
 
+	private getSecondColonPos(str: string) {
+		const indexColon = str.indexOf(':');
+		if (indexColon == -1) {
+			return str.length;
+		}
+
+		const indexSecondColon = str.indexOf(':',indexColon+1);
+		return (indexSecondColon == -1) ? str.length : indexSecondColon;
+	}
+
 	private formatAddr(addr: string) {
-		const indexOfColon = addr.lastIndexOf(':');
-		const firstHalfOfString = addr.substr(0, indexOfColon);
-		const lastHalfOfString = addr.substr(indexOfColon);
+		const indexSecondColon = this.getSecondColonPos(addr);
+		const firstHalfOfString = addr.substr(0, indexSecondColon);
+		const lastHalfOfString = addr.substr(indexSecondColon);
 		return (
 			this.colorTerminalString(
 				firstHalfOfString,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-export const WS_PORTNUM_PLACEHOLDER = '${WS_PORTNUM}';
+export const WS_PORTNUM_PLACEHOLDER = '${WS_URL}';
 
 export const INIT_PANEL_TITLE = '/';
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
-export const WS_PORTNUM_PLACEHOLDER = '${WS_URL}';
+export const WS_URL_PLACEHOLDER = '${WS_URL}';
+export const HTTP_URL_PLACEHOLDER = '${HTTP_URL}';
 
 export const INIT_PANEL_TITLE = '/';
 

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -13,6 +13,7 @@ export interface LiveServerConfigItem {
 	notifyOnOpenLooseFile: boolean;
 	serverWorkspace: string;
 	showWarningOnMultiRootOpen: boolean;
+	runTaskWithExternalPreview: boolean;
 }
 
 export enum AutoRefreshPreview {
@@ -40,6 +41,7 @@ export const Settings: any = {
 	notifyOnOpenLooseFile: 'notifyOnOpenLooseFile',
 	serverWorkspace: 'serverWorkspace',
 	showWarningOnMultiRootOpen: 'showWarningOnMultiRootOpen',
+	runTaskWithExternalPreview: 'runTaskWithExternalPreview',
 };
 export const PreviewType: any = {
 	internalPreview: 'internalPreview',
@@ -81,6 +83,10 @@ export class SettingUtil {
 			serverWorkspace: config.get<string>(Settings.serverWorkspace, ''),
 			showWarningOnMultiRootOpen: config.get<boolean>(
 				Settings.showWarningOnMultiRootOpen,
+				true
+			),
+			runTaskWithExternalPreview: config.get<boolean>(
+				Settings.runTaskWithExternalPreview,
 				true
 			),
 		};


### PR DESCRIPTION
Previously, the previews were not showing on Codespaces because the local previews were navigating to the host address `127.0.0.1`. Changed the implementation to resolve the external URI instead. Running in Codespaces still has the issue that the local address links occasionally need to actually be opened in an external browser to be accessed and the redirect sequence that it goes through is not render-able within an iframe. However, use with Codespaces works much better now.
Relates to https://github.com/microsoft/vscode/issues/128063

De-coupled the task with external opens, since that might be annoying for some people who want to save screen space.
Closes https://github.com/microsoft/vscode/issues/128148