### PR TITLE
"Start Server" Command and Untitled File Previewing

### DIFF
--- a/media/inject_script.html
+++ b/media/inject_script.html
@@ -10,11 +10,8 @@
 	};
 
 	connection.onclose = (event) => {
-		console.log("Error occurred.");
-		
-		// Inform the user about the error.
-		console.log(event)
-
+		console.log('Error occurred.');
+		console.log(event);
 	};
 	connection.onmessage = (event) => handleSocketMessage(event.data);
 

--- a/media/main.js
+++ b/media/main.js
@@ -6,15 +6,14 @@
 	const vscode = acquireVsCodeApi();
 	const connection = new WebSocket(WS_URL);
 	var fadeLinkID = null;
-	
+
 	leftMostNavGroup = [
 		document.getElementById('back'),
 		document.getElementById('forward'),
-		document.getElementById('reload')
+		document.getElementById('reload'),
 	];
 
 	onLoad();
-
 
 	function onLoad() {
 		handleNavGroup(leftMostNavGroup);
@@ -79,13 +78,13 @@
 	function handleNavGroup(nav) {
 		for (var i = 0; i < nav.length; i++) {
 			const currIndex = i;
-			nav[i].addEventListener('keydown', (event) => handleNavKeyDown(event, nav, currIndex));
-
+			nav[i].addEventListener('keydown', (event) =>
+				handleNavKeyDown(event, nav, currIndex)
+			);
 		}
 	}
 
 	function moveFocusNav(right, nav, startIndex) {
-
 		var numDisabled = 0;
 		var modifier = right ? 1 : -1;
 		index = startIndex;
@@ -173,9 +172,7 @@
 				break;
 			}
 			case 'set-url': {
-				console.log("set-url");
 				msgJSON = JSON.parse(message.text);
-				console.log(msgJSON);
 				setURLBar(msgJSON.fullPath);
 				updateState(msgJSON.pathname);
 				break;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	"activationEvents": [
 		"workspaceContains:**/*.html",
 		"onWebviewPanel:browserPreview",
+		"onCommand:LivePreview.start",
 		"onCommand:LivePreview.start.preview.atIndex",
 		"onCommand:LivePreview.start.preview.atFile",
 		"onCommand:LivePreview.start.externalPreview.atIndex",
@@ -41,6 +42,10 @@
 	"main": "./out/extension.js",
 	"contributes": {
 		"commands": [
+			{
+				"command": "LivePreview.start",
+				"title": "Live Preview: Start Server"
+			},
 			{
 				"command": "LivePreview.config.selectWorkspace",
 				"title": "Live Preview: Select Default Workspace for Server"
@@ -71,6 +76,10 @@
 				"title": "Live Preview: Show Preview (Internal Browser)"
 			},
 			{
+				"command": "LivePreview.setDefaultOpenFile",
+				"title": "Live Preview: Open Automatically on Server Start"
+			},
+			{
 				"command": "LivePreview.end",
 				"title": "Live Preview: Stop Server"
 			}
@@ -88,6 +97,11 @@
 					"command": "LivePreview.start.preview.atFile",
 					"when": "resourceLangId == html",
 					"group": "1_livepreview"
+				},
+				{
+					"command": "LivePreview.setDefaultOpenFile",
+					"when": "resourceLangId == html",
+					"group": "1_livepreview"
 				}
 			],
 			"editor/context": [
@@ -95,9 +109,18 @@
 					"command": "LivePreview.start.preview.atFile",
 					"when": "resourceLangId == html",
 					"group": "1_livepreview"
+				},
+				{
+					"command": "LivePreview.setDefaultOpenFile",
+					"when": "resourceLangId == html",
+					"group": "1_livepreview"
 				}
 			],
 			"commandPalette": [
+				{
+					"command": "LivePreview.start",
+					"when": "!LivePreviewServerOn"
+				},
 				{
 					"command": "LivePreview.start.preview.atFile",
 					"when": "false"
@@ -133,6 +156,10 @@
 					"command": "LivePreview.end",
 					"when": "LivePreviewServerOn",
 					"group": "1_livepreview"
+				},
+				{
+					"command": "LivePreview.setDefaultOpenFile",
+					"when": "false"
 				}
 			]
 		},
@@ -205,6 +232,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Whether or not to pair external preview instances with the Live Preview task. When disabled, the embedded preview closing will not cause the server to close to prevent suddent server disconnection."
+				},
+				"LivePreview.defaultPreviewPath": {
+					"type": "string",
+					"default": "",
+					"description": "The file to automatically show upon starting the server. Leave blank to open at the index."
 				}
 			}
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,11 @@ import TelemetryReporter from 'vscode-extension-telemetry';
 import { BrowserPreview } from './editorPreview/browserPreview';
 import { getWebviewOptions, Manager } from './manager';
 import { EXTENSION_ID } from './utils/constants';
-import { SETTINGS_SECTION_ID, SettingUtil } from './utils/settingsUtil';
+import {
+	Settings,
+	SETTINGS_SECTION_ID,
+	SettingUtil,
+} from './utils/settingsUtil';
 import { GetActiveFile } from './utils/utils';
 
 let reporter: TelemetryReporter;
@@ -30,6 +34,23 @@ export function activate(context: vscode.ExtensionContext) {
 		{},
 		{ numWorkspaceFolders: vscode.workspace.workspaceFolders?.length ?? 0 }
 	);
+
+	vscode.commands.registerCommand(`${SETTINGS_SECTION_ID}.start`, () => {
+		const filePath = SettingUtil.GetConfig(
+			context.extensionUri
+		).defaultPreviewPath;
+		if (filePath == '') {
+			vscode.commands.executeCommand(
+				`${SETTINGS_SECTION_ID}.start.preview.atIndex`
+			);
+		} else {
+			const file = vscode.Uri.parse(filePath);
+			vscode.commands.executeCommand(
+				`${SETTINGS_SECTION_ID}.start.preview.atFile`,
+				file
+			);
+		}
+	});
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
@@ -62,6 +83,14 @@ export function activate(context: vscode.ExtensionContext) {
 					`${SETTINGS_SECTION_ID}.start.${previewType}.atIndex`,
 					file
 				);
+			}
+		)
+	);
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			`${SETTINGS_SECTION_ID}.setDefaultOpenFile`,
+			(file: vscode.Uri) => {
+				SettingUtil.UpdateSettings(Settings.defaultPreviewPath, file.fsPath);
 			}
 		)
 	);

--- a/src/infoManagers/endpointManager.ts
+++ b/src/infoManagers/endpointManager.ts
@@ -15,9 +15,14 @@ export class EndpointManager extends Disposable {
 		const fullParent = PathUtil.GetParentDir(location);
 		const child = PathUtil.GetFileName(location);
 		let result;
+
+		let endpoint_prefix = `/endpoint_${parent}`;
+		if (parent == '.') {
+			endpoint_prefix = `/endpoint_unsaved`;
+		}
 		let endpoint;
 		do {
-			endpoint = `/endpoint_${parent}_${i}`;
+			endpoint = `${endpoint_prefix}_${i}`;
 			result = this._looseFiles.get(endpoint);
 			if (result === fullParent) {
 				return path.join(endpoint, child);

--- a/src/server/serverManager.ts
+++ b/src/server/serverManager.ts
@@ -85,7 +85,7 @@ export class Server extends Disposable {
 			})
 		);
 		this._register(
-			vscode.workspace.onDidCreateFiles(() => {
+			vscode.workspace.onDidCreateFiles((e) => {
 				if (this._reloadOnAnyChange || this._reloadOnSave) {
 					this._wsServer.refreshBrowsers();
 				}

--- a/src/server/serverManager.ts
+++ b/src/server/serverManager.ts
@@ -85,7 +85,7 @@ export class Server extends Disposable {
 			})
 		);
 		this._register(
-			vscode.workspace.onDidCreateFiles((e) => {
+			vscode.workspace.onDidCreateFiles(() => {
 				if (this._reloadOnAnyChange || this._reloadOnSave) {
 					this._wsServer.refreshBrowsers();
 				}

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -14,6 +14,7 @@ export interface LiveServerConfigItem {
 	serverWorkspace: string;
 	showWarningOnMultiRootOpen: boolean;
 	runTaskWithExternalPreview: boolean;
+	defaultPreviewPath: string;
 }
 
 export enum AutoRefreshPreview {
@@ -42,6 +43,7 @@ export const Settings: any = {
 	serverWorkspace: 'serverWorkspace',
 	showWarningOnMultiRootOpen: 'showWarningOnMultiRootOpen',
 	runTaskWithExternalPreview: 'runTaskWithExternalPreview',
+	defaultPreviewPath: 'defaultPreviewPath',
 };
 export const PreviewType: any = {
 	internalPreview: 'internalPreview',
@@ -89,6 +91,7 @@ export class SettingUtil {
 				Settings.runTaskWithExternalPreview,
 				true
 			),
+			defaultPreviewPath: config.get<string>(Settings.defaultPreviewPath, ''),
 		};
 	}
 	public static GetPreviewType(extensionUri: vscode.Uri): string {


### PR DESCRIPTION
You can now use the command palette to start the server when the extension is not activated. Doing so will pop up a preview, and you can customize which file you want for your initial file:

Command:
![image](https://user-images.githubusercontent.com/31675041/124833902-14819300-df3c-11eb-813c-cb52b62311d1.png)

Context menu at file explorer and editor:
![image](https://user-images.githubusercontent.com/31675041/124833937-24997280-df3c-11eb-9b17-ff1d2430fd55.png)

By default, this will open at the index preview (if nothing else is specified)

Closes #43 
Closes #44 

You can now also preview untitled files (although saving the file will need a re-open of the preview).

[![Image from Gyazo](https://i.gyazo.com/f420937f159677c3ac7bbc1a16d69fa6.gif)](https://gyazo.com/f420937f159677c3ac7bbc1a16d69fa6)

Closes #42 