### PR TITLE
Remove unnecesary files from bundled vsix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,8 +2,13 @@
 .vscode-test/**
 out/test/**
 src/**
+.github
 .gitignore
+.prettierrc.yaml
 tsconfig.json
 vsc-extension-quickstart.md
+codicon_copy.js
 node_modules
 test-workspace
+release_notes
+out/extension.js.map


### PR DESCRIPTION
Remove media/scripts/linter files from the extension. `.vsix` size **25Mb** => **150Kb**.