### PR TITLE
Change default external preview + cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "live-server",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,12 +40,8 @@
 		"workspaceContains:**/*.{html,htm,xhtml}",
 		"onWebviewPanel:browserPreview",
 		"onCommand:livePreview.start",
-		"onCommand:livePreview.start.preview.atIndex",
 		"onCommand:livePreview.start.preview.atFile",
-		"onCommand:livePreview.start.externalPreview.atIndex",
-		"onCommand:livePreview.start.internalPreview.atIndex",
-		"onCommand:livePreview.start.externalPreview.atFile",
-		"onCommand:livePreview.start.internalPreview.atFile",
+		"onCommand:livePreview.start.debugPreview.atFile",
 		"onCommand:livePreview.end"
 	],
 	"main": "./out/extension.js",
@@ -56,10 +52,6 @@
 				"title": "Live Preview: Start Server"
 			},
 			{
-				"command": "livePreview.start.preview.atIndex",
-				"title": "Live Preview: Show Preview at Index Page"
-			},
-			{
 				"command": "livePreview.start.preview.atFile",
 				"title": "Live Preview: Show Preview",
 				"icon": "$(open-preview)"
@@ -68,18 +60,6 @@
 				"command": "livePreview.start.debugPreview.atFile",
 				"title": "Live Preview: Show Debug Preview",
 				"icon": "$(debug-alt)"
-			},
-			{
-				"command": "livePreview.start.externalPreview.atIndex",
-				"title": "Live Preview: Show Preview at Index (External Browser)"
-			},
-			{
-				"command": "livePreview.start.internalPreview.atIndex",
-				"title": "Live Preview: Show Preview at Index (Internal Browser)"
-			},
-			{
-				"command": "livePreview.start.externalDebugPreview.atIndex",
-				"title": "Live Preview: Show Debug Preview at Index (External Browser)"
 			},
 			{
 				"command": "livePreview.start.externalPreview.atFile",
@@ -104,18 +84,11 @@
 			}
 		],
 		"menus": {
-			"editor/title/run": [
+			"editor/title": [
 				{
 					"command": "livePreview.start.preview.atFile",
-					"group": "1_livepreview@1",
-					"title": "preview file",
-					"when": "resourceLangId == html"
-				},
-				{
-					"command": "livePreview.start.debugPreview.atFile",
-					"group": "1_livepreview@2",
-					"title": "preview file",
-					"when": "resourceLangId == html"
+					"when": "editorLangId == html && !notebookEditorFocused",
+					"group": "navigation"
 				}
 			],
 			"explorer/context": [
@@ -149,22 +122,6 @@
 				},
 				{
 					"command": "livePreview.start.preview.atFile",
-					"when": "false"
-				},
-				{
-					"command": "livePreview.start.preview.atIndex",
-					"when": "false"
-				},
-				{
-					"command": "livePreview.start.externalPreview.atIndex",
-					"when": "false"
-				},
-				{
-					"command": "livePreview.start.internalPreview.atIndex",
-					"when": "false"
-				},
-				{
-					"command": "livePreview.start.externalDebugPreview.atIndex",
 					"when": "false"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
 		"onCommand:livePreview.start",
 		"onCommand:livePreview.start.preview.atFile",
 		"onCommand:livePreview.start.debugPreview.atFile",
+		"onCommand:livePreview.start.internalPreview.atFile",
+		"onCommand:livePreview.start.externalPreview.atFile",
+		"onCommand:livePreview.start.externalDebugPreview.atFile",
 		"onCommand:livePreview.end"
 	],
 	"main": "./out/extension.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "live-server",
 	"displayName": "Live Preview",
 	"description": "Hosts a local server in your workspace for you to preview your webpages.",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"preview": true,
 	"aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
 	"publisher": "ms-vscode",
@@ -33,7 +33,8 @@
 		"live",
 		"browser",
 		"reload",
-		"refresh"
+		"refresh",
+		"livepreview"
 	],
 	"activationEvents": [
 		"workspaceContains:**/*.{html,htm,xhtml}",
@@ -64,6 +65,11 @@
 				"icon": "$(open-preview)"
 			},
 			{
+				"command": "livePreview.start.debugPreview.atFile",
+				"title": "Live Preview: Show Debug Preview",
+				"icon": "$(debug-alt)"
+			},
+			{
 				"command": "livePreview.start.externalPreview.atIndex",
 				"title": "Live Preview: Show Preview at Index (External Browser)"
 			},
@@ -72,12 +78,17 @@
 				"title": "Live Preview: Show Preview at Index (Internal Browser)"
 			},
 			{
+				"command": "livePreview.start.externalDebugPreview.atIndex",
+				"title": "Live Preview: Show Debug Preview at Index (External Browser)"
+			},
+			{
 				"command": "livePreview.start.externalPreview.atFile",
 				"title": "Live Preview: Show Preview (External Browser)"
 			},
 			{
-				"command": "livePreview.start.externalDebug.atFile",
-				"title": "Live Preview: Debug Preview (External Browser)"
+				"command": "livePreview.start.externalDebugPreview.atFile",
+				"title": "Live Preview: Show Debug Preview (External Browser)",
+				"icon": "$(debug-alt)"
 			},
 			{
 				"command": "livePreview.start.internalPreview.atFile",
@@ -93,11 +104,18 @@
 			}
 		],
 		"menus": {
-			"editor/title": [
+			"editor/title/run": [
 				{
 					"command": "livePreview.start.preview.atFile",
-					"when": "editorLangId == html && !notebookEditorFocused",
-					"group": "navigation"
+					"group": "1_livepreview@1",
+					"title": "preview file",
+					"when": "resourceLangId == html"
+				},
+				{
+					"command": "livePreview.start.debugPreview.atFile",
+					"group": "1_livepreview@2",
+					"title": "preview file",
+					"when": "resourceLangId == html"
 				}
 			],
 			"explorer/context": [
@@ -146,6 +164,10 @@
 					"when": "false"
 				},
 				{
+					"command": "livePreview.start.externalDebugPreview.atIndex",
+					"when": "false"
+				},
+				{
 					"command": "livePreview.start.internalPreview.atFile",
 					"when": "editorLangId == html && !notebookEditorFocused",
 					"group": "1_livepreview"
@@ -156,7 +178,7 @@
 					"group": "1_livepreview"
 				},
 				{
-					"command": "livePreview.start.externalDebug.atFile",
+					"command": "livePreview.start.externalDebugPreview.atFile",
 					"when": "editorLangId == html && !notebookEditorFocused",
 					"group": "1_livepreview"
 				},
@@ -234,6 +256,11 @@
 					"type": "string",
 					"default": "",
 					"description": "The file to automatically show upon starting the server. Leave blank to open at the index."
+				},
+				"livePreview.debugOnExternalPreview": {
+					"type": "boolean",
+					"default": true,
+					"description": "Whether or not to attach the JavaScript debugger on external preview launches."
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -125,6 +125,10 @@
 					"when": "false"
 				},
 				{
+					"command": "livePreview.start.debugPreview.atFile",
+					"when": "false"
+				},
+				{
 					"command": "livePreview.start.internalPreview.atFile",
 					"when": "editorLangId == html && !notebookEditorFocused",
 					"group": "1_livepreview"

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -7,6 +7,7 @@ import { WorkspaceManager } from '../infoManagers/workspaceManager';
 import { ConnectionManager } from '../infoManagers/connectionManager';
 import { WebviewComm } from './webviewComm';
 import { FormatDateTime } from '../utils/utils';
+import { SETTINGS_SECTION_ID, SettingUtil } from '../utils/settingsUtil';
 
 /**
  * @description the embedded preview object, containing the webview panel showing the preview.
@@ -20,11 +21,11 @@ export class BrowserPreview extends Disposable {
 	public readonly onDispose = this._onDisposeEmitter.event;
 
 	// _onShiftToExternalBrowser is fired when the user presses the "Open in browser" button.
-	private readonly _onShiftToExternalBrowser = this._register(
-		new vscode.EventEmitter<void>()
-	);
-	public readonly onShiftToExternalBrowser =
-		this._onShiftToExternalBrowser.event;
+	// private readonly _onShiftToExternalBrowser = this._register(
+	// 	new vscode.EventEmitter<void>()
+	// );
+	// public readonly onShiftToExternalBrowser =
+	// 	this._onShiftToExternalBrowser.event;
 
 	/**
 	 * @description close the embedded browser.
@@ -189,8 +190,14 @@ export class BrowserPreview extends Disposable {
 			const uri = vscode.Uri.parse(givenURI.toString());
 			// tells manager that it can launch browser immediately
 			// task will run in case browser preview is closed.
-			this._onShiftToExternalBrowser.fire();
-			vscode.env.openExternal(uri);
+			// this._onShiftToExternalBrowser.fire();
+			vscode.commands.executeCommand(
+				`${SETTINGS_SECTION_ID}.start.${SettingUtil.GetExternalPreviewType(
+					this._extensionUri
+				)}.atFile`,
+				uri
+			);
+			// vscode.env.openExternal(uri);
 		} else {
 			const uri = vscode.Uri.parse(givenURL);
 			vscode.window
@@ -202,7 +209,13 @@ export class BrowserPreview extends Disposable {
 				.then((selection: vscode.MessageItem | undefined) => {
 					if (selection) {
 						if (selection === OPEN_EXTERNALLY) {
-							vscode.env.openExternal(uri);
+							// vscode.env.openExternal(uri);
+							vscode.commands.executeCommand(
+								`${SETTINGS_SECTION_ID}.start.${SettingUtil.GetExternalPreviewType(
+									this._extensionUri
+								)}.atFile`,
+								uri
+							);
 						}
 					}
 				});

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -20,13 +20,6 @@ export class BrowserPreview extends Disposable {
 	);
 	public readonly onDispose = this._onDisposeEmitter.event;
 
-	// _onShiftToExternalBrowser is fired when the user presses the "Open in browser" button.
-	// private readonly _onShiftToExternalBrowser = this._register(
-	// 	new vscode.EventEmitter<void>()
-	// );
-	// public readonly onShiftToExternalBrowser =
-	// 	this._onShiftToExternalBrowser.event;
-
 	/**
 	 * @description close the embedded browser.
 	 */
@@ -188,9 +181,6 @@ export class BrowserPreview extends Disposable {
 				this._webviewComm.currentAddress
 			);
 			const uri = vscode.Uri.parse(givenURI.toString());
-			// tells manager that it can launch browser immediately
-			// task will run in case browser preview is closed.
-			// this._onShiftToExternalBrowser.fire();
 			vscode.commands.executeCommand(
 				`${SETTINGS_SECTION_ID}.start.${SettingUtil.GetExternalPreviewType(
 					this._extensionUri

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -187,7 +187,6 @@ export class BrowserPreview extends Disposable {
 				)}.atFile`,
 				uri
 			);
-			// vscode.env.openExternal(uri);
 		} else {
 			const uri = vscode.Uri.parse(givenURL);
 			vscode.window

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -184,6 +184,38 @@ export function activate(context: vscode.ExtensionContext): void {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
+			`${SETTINGS_SECTION_ID}.start.externalDebugPreview.atIndex`,
+			() => {
+				/* __GDPR__
+					"preview" :{
+						"type" : {"classification": "SystemMetaData", "purpose": "FeatureInsight"},
+						"location" : {"classification": "SystemMetaData", "purpose": "FeatureInsight"}
+					}
+				*/
+				reporter.sendTelemetryEvent('preview', {
+					type: 'external',
+					location: 'atIndex',
+					debug: 'true',
+				});
+				manager.showPreviewInBrowser('/', true, true);
+			}
+		)
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			`${SETTINGS_SECTION_ID}.start.debugPreview.atIndex`,
+			() => {
+				// TODO: implement internalDebugPreview and use settings to choose which one to launch
+				vscode.commands.executeCommand(
+					`${SETTINGS_SECTION_ID}.start.externalDebugPreview.atIndex`
+				);
+			}
+		)
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
 			`${SETTINGS_SECTION_ID}.start.internalPreview.atIndex`,
 			() => {
 				/* __GDPR__
@@ -223,6 +255,40 @@ export function activate(context: vscode.ExtensionContext): void {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
+			`${SETTINGS_SECTION_ID}.start.externalDebugPreview.atFile`,
+			(file?: any, relativeFileString = true) => {
+				/* __GDPR__
+					"preview" :{
+						"type" : {"classification": "SystemMetaData", "purpose": "FeatureInsight"},
+						"location" : {"classification": "SystemMetaData", "purpose": "FeatureInsight"}
+					}
+				*/
+				reporter.sendTelemetryEvent('preview', {
+					type: 'external',
+					location: 'atFile',
+					debug: 'true',
+				});
+				handleOpenFile(false, file, relativeFileString, true);
+			}
+		)
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
+			`${SETTINGS_SECTION_ID}.start.debugPreview.atFile`,
+			(file?: any, relativeFileString = true) => {
+				// TODO: implement internalDebugPreview and use settings to choose which one to launch
+				vscode.commands.executeCommand(
+					`${SETTINGS_SECTION_ID}.start.externalDebugPreview.atFile`,
+					file,
+					relativeFileString
+				);
+			}
+		)
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand(
 			`${SETTINGS_SECTION_ID}.start.internalPreview.atFile`,
 			(file?: any, relativeFileString = true) => {
 				/* __GDPR__
@@ -250,26 +316,6 @@ export function activate(context: vscode.ExtensionContext): void {
 				vscode.window.showErrorMessage('Server already off.');
 			}
 		})
-	);
-
-	context.subscriptions.push(
-		vscode.commands.registerCommand(
-			`${SETTINGS_SECTION_ID}.start.externalDebug.atFile`,
-			(file?: any, relativeFileString = true) => {
-				/* __GDPR__
-					"preview" :{
-						"type" : {"classification": "SystemMetaData", "purpose": "FeatureInsight"},
-						"location" : {"classification": "SystemMetaData", "purpose": "FeatureInsight"}
-					}
-				*/
-				reporter.sendTelemetryEvent('preview', {
-					type: 'external',
-					location: 'atFile',
-					debug: 'true',
-				});
-				handleOpenFile(false, file, relativeFileString, true);
-			}
-		)
 	);
 
 	if (vscode.window.registerWebviewPanelSerializer) {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -468,19 +468,19 @@ export class Manager extends Disposable {
 
 		this._previewActive = true;
 
-		this._register(
-			this.currentPanel.onShiftToExternalBrowser(() => {
-				if (
-					!this._serverTaskProvider.isRunning &&
-					this._runTaskWithExternalPreview
-				) {
-					this._serverTaskProvider.extRunTask(
-						SettingUtil.GetConfig(this._extensionUri)
-							.browserPreviewLaunchServerLogging
-					);
-				}
-			})
-		);
+		// this._register(
+		// 	this.currentPanel.onShiftToExternalBrowser(() => {
+		// 		if (
+		// 			!this._serverTaskProvider.isRunning &&
+		// 			this._runTaskWithExternalPreview
+		// 		) {
+		// 			this._serverTaskProvider.extRunTask(
+		// 				SettingUtil.GetConfig(this._extensionUri)
+		// 					.browserPreviewLaunchServerLogging
+		// 			);
+		// 		}
+		// 	})
+		// );
 
 		this._register(
 			this.currentPanel.onDispose(() => {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -468,20 +468,6 @@ export class Manager extends Disposable {
 
 		this._previewActive = true;
 
-		// this._register(
-		// 	this.currentPanel.onShiftToExternalBrowser(() => {
-		// 		if (
-		// 			!this._serverTaskProvider.isRunning &&
-		// 			this._runTaskWithExternalPreview
-		// 		) {
-		// 			this._serverTaskProvider.extRunTask(
-		// 				SettingUtil.GetConfig(this._extensionUri)
-		// 					.browserPreviewLaunchServerLogging
-		// 			);
-		// 		}
-		// 	})
-		// );
-
 		this._register(
 			this.currentPanel.onDispose(() => {
 				this.currentPanel = undefined;

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -14,6 +14,7 @@ export interface LiveServerConfigItem {
 	notifyOnOpenLooseFile: boolean;
 	runTaskWithExternalPreview: boolean;
 	defaultPreviewPath: string;
+	debugOnExternalPreview: boolean;
 }
 
 /**
@@ -53,6 +54,7 @@ export const Settings: any = {
 	notifyOnOpenLooseFile: 'notifyOnOpenLooseFile',
 	runTaskWithExternalPreview: 'tasks.runTaskWithExternalPreview',
 	defaultPreviewPath: 'defaultPreviewPath',
+	debugOnExternalPreview: 'debugOnExternalPreview',
 };
 
 /**
@@ -61,6 +63,7 @@ export const Settings: any = {
 export const PreviewType: any = {
 	internalPreview: 'internalPreview',
 	externalPreview: 'externalPreview',
+	externalDebugPreview: 'externalDebugPreview',
 };
 
 export class SettingUtil {
@@ -106,6 +109,10 @@ export class SettingUtil {
 				true
 			),
 			defaultPreviewPath: config.get<string>(Settings.defaultPreviewPath, ''),
+			debugOnExternalPreview: config.get<boolean>(
+				Settings.debugOnExternalPreview,
+				true
+			),
 		};
 	}
 
@@ -121,10 +128,17 @@ export class SettingUtil {
 		) {
 			return PreviewType.internalPreview;
 		} else {
-			return PreviewType.externalPreview;
+			return SettingUtil.GetExternalPreviewType(extensionUri);
 		}
 	}
 
+	public static GetExternalPreviewType(extensionUri: vscode.Uri): string {
+		if (SettingUtil.GetConfig(extensionUri).debugOnExternalPreview) {
+			return PreviewType.externalDebugPreview;
+		} else {
+			return PreviewType.externalPreview;
+		}
+	}
 	/**
 	 * @description Update a Live Preview setting
 	 * @param {string} settingSuffix the suffix, `livePreview.<suffix>` of the setting to set.


### PR DESCRIPTION
- removed `atIndex` commands (the same behavior can be done by using the `atFile` command with argument `/`)
- made the debug external preview the default external preview + made it configurable.