### PR TITLE
Limit Activation Cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ Changes have only been tracked starting from `v0.2.2`
 - General code cleanup. [#103](https://github.com/microsoft/vscode-livepreview/pull/103)
 - Changed external debug preview to be the default external preview. [#105](https://github.com/microsoft/vscode-livepreview/pull/105)
   - Added "Debug on External Preview" to allow users to modify the default external browser behavior.
+- Changed activation to require user to be on HTML file rather than if the workspace contains an HTML file. [#110](https://github.com/microsoft/vscode-livepreview/pull/110)

--- a/package.json
+++ b/package.json
@@ -37,15 +37,14 @@
 		"livepreview"
 	],
 	"activationEvents": [
-		"workspaceContains:**/*.{html,htm,xhtml}",
+		"onLanguage:html",
 		"onWebviewPanel:browserPreview",
 		"onCommand:livePreview.start",
 		"onCommand:livePreview.start.preview.atFile",
 		"onCommand:livePreview.start.debugPreview.atFile",
 		"onCommand:livePreview.start.internalPreview.atFile",
 		"onCommand:livePreview.start.externalPreview.atFile",
-		"onCommand:livePreview.start.externalDebugPreview.atFile",
-		"onCommand:livePreview.end"
+		"onCommand:livePreview.start.externalDebugPreview.atFile"
 	],
 	"main": "./out/extension.js",
 	"contributes": {


### PR DESCRIPTION
Change activation from `workspaceContains:**/*.{html,htm,xhtml}` to `onLanguage:html`. If a user wants to activate outside of an HTML file, they can always call `Start Server` and it will open index or the file that the specify in settings (`DefaultPreviewPath`).

Closes #107