### PR TITLE
add option to configure host IP

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,6 +224,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Whether or not to attach the JavaScript debugger on external preview launches."
+				},
+				"livePreview.hostIP": {
+					"type": "string",
+					"default": "127.0.0.1",
+					"description": "The local IP host address to host your files on."
 				}
 			}
 		},

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -4,7 +4,6 @@ import { Disposable } from './utils/dispose';
 import { Server } from './server/serverManager';
 import {
 	INIT_PANEL_TITLE,
-	HOST,
 	DONT_SHOW_AGAIN,
 	OUTPUT_CHANNEL_NAME,
 } from './utils/constants';
@@ -81,8 +80,9 @@ export class Manager extends Disposable {
 		);
 		const serverPort = SettingUtil.GetConfig(_extensionUri).portNumber;
 		const serverWSPort = serverPort;
+		const serverHost = SettingUtil.GetConfig(_extensionUri).hostIP;
 		this._connectionManager = this._register(
-			new ConnectionManager(serverPort, serverWSPort)
+			new ConnectionManager(serverPort, serverWSPort, serverHost)
 		);
 
 		this._server = this._register(
@@ -99,7 +99,8 @@ export class Manager extends Disposable {
 		this._serverTaskProvider = new ServerTaskProvider(
 			this._reporter,
 			this._endpointManager,
-			this._workspaceManager
+			this._workspaceManager,
+			this._connectionManager
 		);
 
 		this._runTaskWithExternalPreview =
@@ -165,6 +166,9 @@ export class Manager extends Disposable {
 				this._connectionManager.pendingPort = SettingUtil.GetConfig(
 					this._extensionUri
 				).portNumber;
+				this._connectionManager.pendingHost = SettingUtil.GetConfig(
+					this._extensionUri
+				).hostIP;
 				this._runTaskWithExternalPreview = SettingUtil.GetConfig(
 					this._extensionUri
 				).runTaskWithExternalPreview;
@@ -434,7 +438,7 @@ export class Manager extends Disposable {
 			this.transformNonRelativeFile(relative, file)
 		);
 
-		const url = `http://${HOST}:${this._serverPort}${relFile}`;
+		const url = `http://${this._connectionManager.host}:${this._serverPort}${relFile}`;
 		if (debug) {
 			vscode.commands.executeCommand('extension.js-debug.debugLink', url);
 		} else {

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Disposable } from '../utils/dispose';
 import { ContentLoader } from './serverUtils/contentLoader';
-import { HOST, INJECTED_ENDPOINT_NAME } from '../utils/constants';
+import { INJECTED_ENDPOINT_NAME } from '../utils/constants';
 import { serverMsg } from '../manager';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { EndpointManager } from '../infoManagers/endpointManager';
@@ -22,7 +22,7 @@ export class HttpServer extends Disposable {
 		private readonly _reporter: TelemetryReporter,
 		private readonly _endpointManager: EndpointManager,
 		private readonly _workspaceManager: WorkspaceManager,
-		_connectionManager: ConnectionManager
+		private readonly _connectionManager: ConnectionManager
 	) {
 		super();
 		this._contentLoader = this._register(
@@ -101,7 +101,10 @@ export class HttpServer extends Disposable {
 		this._server.on('error', (err: any) => {
 			if (err.code == 'EADDRINUSE') {
 				this.port++;
-				this._server.listen(this.port, HOST);
+				this._server.listen(this.port, this._connectionManager.host);
+			} else if (err.code == 'EADDRNOTAVAIL') {
+				this._connectionManager.resetHostToDefault();
+				this._server.listen(this.port, this._connectionManager.host);
 			} else {
 				/* __GDPR__
 					"server.err" : { 
@@ -117,7 +120,7 @@ export class HttpServer extends Disposable {
 			}
 		});
 
-		this._server.listen(this.port, HOST);
+		this._server.listen(this.port, this._connectionManager.host);
 		return true;
 	}
 

--- a/src/server/serverManager.ts
+++ b/src/server/serverManager.ts
@@ -11,7 +11,6 @@ import {
 } from '../utils/settingsUtil';
 import {
 	DONT_SHOW_AGAIN,
-	HOST,
 	LIVE_PREVIEW_SERVER_ON,
 	UriSchemes,
 } from '../utils/constants';
@@ -223,12 +222,12 @@ export class Server extends Disposable {
 	): void {
 		let port = startPort;
 		const sock = new net.Socket();
-
+		const host = this._connectionManager.host;
 		sock.setTimeout(500);
 		sock.on('connect', function () {
 			sock.destroy();
 			port++;
-			sock.connect(port, HOST);
+			sock.connect(port, host);
 		});
 		sock.on('error', function (e) {
 			callback(port);
@@ -236,7 +235,7 @@ export class Server extends Disposable {
 		sock.on('timeout', function () {
 			callback(port);
 		});
-		sock.connect(port, HOST);
+		sock.connect(port, host);
 	}
 
 	/**

--- a/src/task/serverTaskLinkProvider.ts
+++ b/src/task/serverTaskLinkProvider.ts
@@ -2,10 +2,10 @@ import { Disposable } from '../utils/dispose';
 import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { EndpointManager } from '../infoManagers/endpointManager';
-import { HOST } from '../utils/constants';
 import { URL } from 'url';
 import { WorkspaceManager } from '../infoManagers/workspaceManager';
 import { SETTINGS_SECTION_ID } from '../utils/settingsUtil';
+import { ConnectionManager } from '../infoManagers/connectionManager';
 
 /**
  * @description the link provider that runs on Live Preview's `Run Server` task
@@ -27,7 +27,8 @@ export class serverTaskLinkProvider
 		public terminalName: string,
 		private readonly _reporter: TelemetryReporter,
 		private readonly _endpointManager: EndpointManager,
-		private readonly _workspaceManager: WorkspaceManager
+		private readonly _workspaceManager: WorkspaceManager,
+		private readonly _connectionManager: ConnectionManager
 	) {
 		super();
 		vscode.window.registerTerminalLinkProvider(this);
@@ -126,7 +127,7 @@ export class serverTaskLinkProvider
 
 	private _findFullLinkRegex(input: string, links: Array<vscode.TerminalLink>) {
 		const fullLinkRegex = new RegExp(
-			`\\b\\w{2,20}:\\/\\/(?:localhost|${HOST}|:\\d{2,5})[\\w\\-.~:/?#[\\]@!$&()*+,;=]*`,
+			`\\b\\w{2,20}:\\/\\/(?:localhost|${this._connectionManager.host}|:\\d{2,5})[\\w\\-.~:/?#[\\]@!$&()*+,;=]*`,
 			'g'
 		);
 

--- a/src/task/serverTaskProvider.ts
+++ b/src/task/serverTaskProvider.ts
@@ -7,6 +7,7 @@ import { Disposable } from '../utils/dispose';
 import { serverTaskLinkProvider } from './serverTaskLinkProvider';
 import { ServerTaskTerminal } from './serverTaskTerminal';
 import { TASK_TERMINAL_NAME } from '../utils/constants';
+import { ConnectionManager } from '../infoManagers/connectionManager';
 
 interface ServerTaskDefinition extends vscode.TaskDefinition {
 	args: string[];
@@ -62,7 +63,8 @@ export class ServerTaskProvider
 	constructor(
 		private readonly _reporter: TelemetryReporter,
 		endpointManager: EndpointManager,
-		private readonly _workspaceManager: WorkspaceManager
+		private readonly _workspaceManager: WorkspaceManager,
+		_connectionManager: ConnectionManager
 	) {
 		super();
 		this._terminalLinkProvider = this._register(
@@ -70,7 +72,8 @@ export class ServerTaskProvider
 				'',
 				_reporter,
 				endpointManager,
-				_workspaceManager
+				_workspaceManager,
+				_connectionManager
 			)
 		);
 		this._terminalLinkProvider.onRequestOpenEditorToSide((e) => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -13,7 +13,7 @@ export const OPEN_EXTERNALLY: vscode.MessageItem = {
 	title: 'Open Externally',
 };
 
-export const HOST = '127.0.0.1';
+export const DEFAULT_HOST = '127.0.0.1';
 
 export const EXTENSION_ID = 'ms-vscode.live-server';
 

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -15,6 +15,7 @@ export interface LiveServerConfigItem {
 	runTaskWithExternalPreview: boolean;
 	defaultPreviewPath: string;
 	debugOnExternalPreview: boolean;
+	hostIP: string;
 }
 
 /**
@@ -55,6 +56,7 @@ export const Settings: any = {
 	runTaskWithExternalPreview: 'tasks.runTaskWithExternalPreview',
 	defaultPreviewPath: 'defaultPreviewPath',
 	debugOnExternalPreview: 'debugOnExternalPreview',
+	hostIP: 'hostIP',
 };
 
 /**
@@ -113,6 +115,7 @@ export class SettingUtil {
 				Settings.debugOnExternalPreview,
 				true
 			),
+			hostIP: config.get<string>(Settings.hostIP, '127.0.0.1'),
 		};
 	}
 


### PR DESCRIPTION
Added a setting for custom IP. The extension will check for bad IP formatting or inability to connect. In these cases, it will fall back to `127.0.0.1`.
![image](https://user-images.githubusercontent.com/31675041/126917502-1245a49d-f818-433f-8aea-fcfbd4aa72fb.png)
![image](https://user-images.githubusercontent.com/31675041/126917519-79e23d58-6947-47a2-84c9-9818bd9f0e23.png)

Closes #97