### PR TITLE
Print Exception in Console

### DIFF
--- a/media/injectScript.js
+++ b/media/injectScript.js
@@ -5,6 +5,7 @@
  */
 
 window.addEventListener('message', (event) => handleMessage(event), false);
+window.addEventListener('error', (event) => handleError(event), false);
 
 document.addEventListener('DOMContentLoaded', function (e) {
 	onLoad();
@@ -175,6 +176,31 @@ function handleMessage(event) {
 				postParentMessage(event.data);
 			}
 		}
+	}
+}
+
+/**
+ * Handle errors from the parent (specifically for embedded preview).
+ * @param {any} event
+ */
+function handleError(event) {
+	const stackMessage = event.error.stack;
+	// stackMessages given in the form:
+	//    "errorType: errorMessage"
+	// Example:
+	//    "SyntaxError: Illegal newline after throw"
+	const errorType = stackMessage.split(':')[0];
+
+	// ignore errors such as SyntaxError, ReferenceError, etc
+	if (errorType === 'Error') {
+		const messagePayload = {
+			type: 'UNCAUGHT_ERROR',
+			data: stackMessage,
+		};
+		postParentMessage({
+			command: 'console',
+			text: JSON.stringify(messagePayload),
+		});
 	}
 }
 


### PR DESCRIPTION
resolve #129 @mjbvz @andreamah 

use an event listener to check for errors and logs them in the output console.
![image](https://user-images.githubusercontent.com/16089850/127786599-0900643c-a609-471b-8436-5c88b26d3347.png)
