### PR TITLE
Fixed Functions Printed as Undefined

### DIFF
--- a/media/injectScript.js
+++ b/media/injectScript.js
@@ -83,6 +83,7 @@ function createConsoleOverride(type) {
 
 		try {
 			stringifiedMsg = JSON.stringify(msg);
+			if (!stringifiedMsg) throw new Error('stringifiedMsg is undefined');
 		} catch (err) {
 			try {
 				stringifiedMsg = msg.toString();

--- a/media/injectScript.js
+++ b/media/injectScript.js
@@ -83,7 +83,7 @@ function createConsoleOverride(type) {
 
 		try {
 			stringifiedMsg = JSON.stringify(msg);
-			if (!stringifiedMsg) throw new Error('stringifiedMsg is undefined');
+			if (!stringifiedMsg) throw new Error('message is not in JSON format');
 		} catch (err) {
 			try {
 				stringifiedMsg = msg.toString();


### PR DESCRIPTION
resolve #128 @mjbvz @andreamah 
```javascript
JSON.stringify(()=>{}) 
```
produces undefined instead of an error.

Checks if stringifiedMsg is undefined and throw an error.
![image](https://user-images.githubusercontent.com/16089850/127789542-b174c76c-85ac-47a7-90b2-03fb370d5682.png)
