### PR TITLE
fix iteration over inhereted array props; prop parent existance checks

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -244,7 +244,9 @@
 			// from extension
 			case 'changed-history': {
 				const msgJSON = JSON.parse(message.text);
-				document.getElementById(msgJSON.element).disabled = msgJSON.disabled;
+				if (msgJSON.element) {
+					document.getElementById(msgJSON.element).disabled = msgJSON.disabled;
+				}
 				adjustTabIndex();
 				break;
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -244,7 +244,7 @@ export function activate(context: vscode.ExtensionContext): void {
 				state: any
 			) {
 				let relative = true;
-				let file = unescape(state.currentAddress) ?? '/';
+				let file = (state && unescape(state.currentAddress)) ?? '/';
 
 				if (!manager.pathExistsRelativeToWorkspace(file)) {
 					const absFile = manager.decodeEndpoint(file);

--- a/src/server/serverUtils/HTMLInjector.ts
+++ b/src/server/serverUtils/HTMLInjector.ts
@@ -86,14 +86,13 @@ export class HTMLInjector extends Disposable {
 	 * @returns {string} string with all replacements performed on.
 	 */
 	private replace(script: string, replaces: replaceObj[]): string {
-		for (const i in replaces) {
-			const replace = replaces[i];
+		replaces.forEach(replace=>{
 			const placeHolderIndex = script.indexOf(replace.original);
 			script =
 				script.substr(0, placeHolderIndex) +
 				replace.replacement +
 				script.substr(placeHolderIndex + replace.original.length);
-		}
+		});
 		return script;
 	}
 


### PR DESCRIPTION
It still doesn't work (doesn't refresh after the load no matter the settings) but at least the console is clean. 

Please never use ``for in`` - you risk to tap into inherited properties of the array/object. It's not even less code at this point.