### PR TITLE
Per-page reload opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ The simple embedded browser features the following:
 See the changes as you make them. By default, changes appear as you make them in the editor. You can also change this in settings to refresh the preview on save or not at all. 
 
 ![live-refresh](https://raw.githubusercontent.com/microsoft/vscode-livepreview/main/img/live-refresh.gif)
+
+Individual pages can opt out of live refreshing by adding the `<body>` attribute `data-server-no-reload`.
+
 ### Persistent Server Task with Server Logging
 If you're looking for a persistent server to run, you can run a `Live Preview` task, which can optionally log the server traffic. You can also click on the traffic to open the file location of the file returned by the server.
 

--- a/media/injectScript.js
+++ b/media/injectScript.js
@@ -156,6 +156,9 @@ function handleMessage(event) {
 		case 'refresh':
 			reloadPage();
 			break;
+		case 'refresh-forced':
+			window.location.reload();
+			break;
 		case 'setup-parent-listener': {
 			const commandPayload = {
 				path: window.location,
@@ -314,7 +317,7 @@ function handleLinkHoverEnd() {
 
 /**
  * Reloads page when requested by a socket message or parent.
- * Reloading is prevented if the document body has a `data-server-no-reload` attribute.
+ * Auto-reloading is prevented if the document body has a `data-server-no-reload` attribute.
  */
 function reloadPage() {
 	const block = (document.body) ? document.body.hasAttribute('data-server-no-reload') : false;

--- a/media/injectScript.js
+++ b/media/injectScript.js
@@ -140,7 +140,7 @@ function handleSocketMessage(data) {
 	const parsedMessage = JSON.parse(data);
 	switch (parsedMessage.command) {
 		case 'reload': {
-			window.location.reload();
+			reloadPage();
 		}
 	}
 }
@@ -154,7 +154,7 @@ function handleMessage(event) {
 
 	switch (message.command) {
 		case 'refresh':
-			window.location.reload();
+			reloadPage();
 			break;
 		case 'setup-parent-listener': {
 			const commandPayload = {
@@ -283,10 +283,10 @@ function handleLinkClick(linkTarget) {
 			// The embedded preview does not support external sites; let the extension know that an external link has been
 			// opened in the embedded preview; this will open the modal to ask the user to navigate in an external browser
 			// and will force the embedded preview back to the previous page.
-			postParentMessage({ command: 'open-external-link', text: linkTarget });
+			postParentMessage({command: 'open-external-link', text: linkTarget});
 		} else {
 			// Check all local URLs to make sure to catch pages that won't be injectable
-			postParentMessage({ command: 'perform-url-check', text: linkTarget });
+			postParentMessage({command: 'perform-url-check', text: linkTarget});
 		}
 	}
 }
@@ -310,4 +310,14 @@ function handleLinkHoverEnd() {
 	postParentMessage({
 		command: 'link-hover-end',
 	});
+}
+
+/**
+ * Reloads page when requested by a socket message or parent.
+ * Reloading is prevented if the document body has a `data-server-no-reload` attribute.
+ */
+function reloadPage() {
+	const block = (document.body) ? document.body.hasAttribute('data-server-no-reload') : false;
+	if (block) return;
+	window.location.reload();
 }

--- a/media/main.js
+++ b/media/main.js
@@ -433,7 +433,7 @@
 		document.getElementById('reload').onclick = function () {
 			document
 				.getElementById('hostedContent')
-				.contentWindow.postMessage({ command: 'refresh' }, '*');
+				.contentWindow.postMessage({ command: 'refresh-forced'}, '*');
 			document.getElementById('reload').blur();
 		};
 


### PR DESCRIPTION
TLDR; If the attribute `data-server-no-reload` is found on the `<body>` tag, commands to reload the page are ignored.

At the moment, all browser windows are reloaded when there is a source change, regardless of whether the source change affects them. This is a robust, base logic.

However, there are instances where one wants to prevent a page from being reloaded by changes. Eg, if _a.html_ opens up a connection to a media device, a change in _b.html_ will cause _a.html_ to be perhaps unnecessarily reloaded. This requires a manual re-starting of the stream, and other state may be lost.

This addition changes the injection script to check for the presence of an attribute on the `BODY` element. If it's there, the reload requests are ignored, and the page will have to be manually reloaded. The user can explicitly opt out of automatic reloading for pages they want manual control over, which otherwise is not currently possible.

It uses the same attribute name as [Five Server](https://github.com/yandeu/five-server) so the behaviour is identical regardless of which extension is used.

(Some other minor formatting changes happened applying the repo's eslint rules)

Fixes #241