### PR TITLE
Remove hardcoded UTF-8 content type

### DIFF
--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -257,7 +257,7 @@ export class HttpServer extends Disposable {
 			});
 			res.writeHead(200, {
 				'Accept-Ranges': 'bytes',
-				'Content-Type': `${contentType}; charset=UTF-8`,
+				'Content-Type': contentType,
 			});
 			stream.pipe(res);
 		} else {

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -107,7 +107,7 @@ export class HttpServer extends Disposable {
 				this._server.listen(this.port, this._connectionManager.host);
 			} else {
 				/* __GDPR__
-					"server.err" : { 
+					"server.err" : {
 						"type": {"classification": "SystemMetaData", "purpose": "FeatureInsight"},
 						"err": {"classification": "CallstackOrException", "purpose": "PerformanceAndHealth"}
 					}
@@ -146,7 +146,7 @@ export class HttpServer extends Disposable {
 			const contentType = respInfo.ContentType ?? '';
 			res.writeHead(200, {
 				'Accept-Ranges': 'bytes',
-				'Content-Type': `${contentType}; charset=UTF-8`,
+				'Content-Type': contentType,
 			});
 			stream = respInfo.Stream;
 			stream?.pipe(res);
@@ -160,7 +160,7 @@ export class HttpServer extends Disposable {
 			const respInfo = this._contentLoader.createNoRootServer();
 			res.writeHead(404, {
 				'Accept-Ranges': 'bytes',
-				'Content-Type': `${respInfo.ContentType}; charset=UTF-8`,
+				'Content-Type': respInfo.ContentType,
 			});
 			this.reportStatus(req, res);
 			stream = respInfo.Stream;
@@ -172,7 +172,7 @@ export class HttpServer extends Disposable {
 		let looseFile = false;
 		URLPathName = decodeURI(URLPathName);
 		let absoluteReadPath = path.join(basePath ?? '', URLPathName);
-		
+
 		let contentType = 'application/octet-stream';
 
 		if (URLPathName.startsWith('/endpoint_unsaved')) {
@@ -188,7 +188,7 @@ export class HttpServer extends Disposable {
 				contentType = content.ContentType ?? '';
 				res.writeHead(200, {
 					'Accept-Ranges': 'bytes',
-					'Content-Type': `${contentType}; charset=UTF-8`,
+					'Content-Type': contentType,
 				});
 				stream.pipe(res);
 				return;
@@ -206,7 +206,7 @@ export class HttpServer extends Disposable {
 					this._contentLoader.createPageDoesNotExist(absoluteReadPath);
 				res.writeHead(404, {
 					'Accept-Ranges': 'bytes',
-					'Content-Type': `${respInfo.ContentType}; charset=UTF-8`,
+					'Content-Type': respInfo.ContentType,
 				});
 				this.reportStatus(req, res);
 				stream = respInfo.Stream;

--- a/src/server/serverUtils/contentLoader.ts
+++ b/src/server/serverUtils/contentLoader.ts
@@ -92,7 +92,7 @@ export class ContentLoader extends Disposable {
 
 		return {
 			Stream: Stream.Readable.from(fileString),
-			ContentType: 'text/javascript',
+			ContentType: 'text/javascript; charset=UTF-8',
 		};
 	}
 
@@ -122,7 +122,7 @@ export class ContentLoader extends Disposable {
 
 		return {
 			Stream: Stream.Readable.from(htmlString),
-			ContentType: 'text/html',
+			ContentType: 'text/html; charset=UTF-8',
 		};
 	}
 
@@ -167,7 +167,7 @@ export class ContentLoader extends Disposable {
 
 		return {
 			Stream: Stream.Readable.from(htmlString),
-			ContentType: 'text/html',
+			ContentType: 'text/html; charset=UTF-8',
 		};
 	}
 
@@ -262,14 +262,14 @@ export class ContentLoader extends Disposable {
 				${directoryContents}
 			</table>
 			</body>
-			
+
 			${this._scriptInjection}
 		</html>
 		`;
 
 		return {
 			Stream: Stream.Readable.from(htmlString),
-			ContentType: 'text/html',
+			ContentType: 'text/html; charset=UTF-8',
 		};
 	}
 
@@ -313,6 +313,10 @@ export class ContentLoader extends Disposable {
 			} else {
 				stream = fs.createReadStream(readPath);
 			}
+		}
+
+		if (contentType.startsWith('text/')) {
+			contentType = `${contentType}; charset=UTF-8`;
 		}
 
 		return {


### PR DESCRIPTION
Fixes #144

I believe that the `Content-Type: charset=UTF-8` flag is no longer needed for hosting if it's not a `text/` mimetype.

Tested with the code from [this tutorial](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming)