### PR TITLE
Refine task process to make more sense

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
 		"onCommand:livePreview.start.debugPreview.atFile",
 		"onCommand:livePreview.start.internalPreview.atFile",
 		"onCommand:livePreview.start.externalPreview.atFile",
-		"onCommand:livePreview.start.externalDebugPreview.atFile"
+		"onCommand:livePreview.start.externalDebugPreview.atFile",
+		"onTaskType:Live Preview"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -238,18 +239,10 @@
 		"taskDefinitions": [
 			{
 				"type": "Live Preview",
-				"required": [
-					"args"
-				],
 				"properties": {
-					"args": {
-						"type": "array",
-						"description": "%tasks.argsDesc%"
-					}
-          ,
 					"workspacePath": {
 						"type": "string",
-						"description": "%tasks.workspaceUriDesc%"
+						"description": "%tasks.workspacePathDesc%"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
 				},
 				"livePreview.tasks.runTaskWithExternalPreview": {
 					"type": "boolean",
-					"default": true,
+					"default": false,
 					"description": "%settings.tasks.runTaskWithExternalPreview%"
 				},
 				"livePreview.defaultPreviewPath": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,6 +19,5 @@
 	"settings.defaultPreviewPath": "The file to automatically show upon starting the server. Leave blank to open at the index.",
 	"settings.debugOnExternalPreview": "Whether or not to attach the JavaScript debugger on external preview launches.",
 	"settings.hostIP": "The local IP host address to host your files on.",
-	"tasks.argsDesc": "Whether to show incoming server messages and status codes.",
-	"tasks.workspaceUriDesc": "The URI for the workspace that you want to start the server in."
+	"tasks.workspacePathDesc": "The path for the workspace that you want to start the server in."
 }

--- a/src/server/serverGrouping.ts
+++ b/src/server/serverGrouping.ts
@@ -327,7 +327,6 @@ export class ServerGrouping extends Disposable {
 				vscode.workspace.workspaceFolders.length > 0
 			) {
 				await this._serverTaskProvider.extRunTask(
-					SettingUtil.GetConfig().browserPreviewLaunchServerLogging,
 					this._connection.workspace
 				);
 			} else {

--- a/src/task/serverTaskTerminal.ts
+++ b/src/task/serverTaskTerminal.ts
@@ -8,7 +8,7 @@ import {
 	TerminalStyleUtil,
 } from '../utils/terminalStyleUtil';
 import { FormatDateTime } from '../utils/utils';
-import { ServerStartedStatus, ServerArgs } from './serverTaskProvider';
+import { ServerStartedStatus } from './serverTaskProvider';
 import { IServerMsg } from '../server/serverGrouping';
 
 const localize = nls.loadMessageBundle();
@@ -37,8 +37,6 @@ export class ServerTaskTerminal
 	public readonly onRequestToCloseServer =
 		this._onRequestToCloseServerEmitter.event;
 
-	private readonly _verbose;
-
 	// `writeEmitter` and `closeEmitter` are inherited from the pseudoterminal.
 	private _onDidWrite = new vscode.EventEmitter<string>();
 	onDidWrite: vscode.Event<string> = this._onDidWrite.event;
@@ -47,7 +45,6 @@ export class ServerTaskTerminal
 	onDidClose?: vscode.Event<number> = this._onDidClose.event;
 
 	constructor(
-		args: string[],
 		private readonly _reporter: TelemetryReporter,
 		private _workspace: vscode.WorkspaceFolder | undefined,
 		private readonly _executeServer = true
@@ -58,7 +55,6 @@ export class ServerTaskTerminal
 				"tasks.terminal.start" : {}
 			*/
 			this._reporter.sendTelemetryEvent('tasks.terminal.start');
-			this._verbose = args.some((x) => x == ServerArgs.verbose);
 		}
 	}
 
@@ -111,20 +107,6 @@ export class ServerTaskTerminal
 		status: ServerStartedStatus
 	): void {
 		const formattedAddress = this._formatAddr(externalUri.toString());
-		if (!this._verbose) {
-			this._onDidWrite.fire(
-				localize(
-					{
-						key: 'noLoggerWarning',
-						comment: [
-							"{Locked='--verbose'}",
-							"Do not translate the '--verbose' part",
-						],
-					},
-					'This task does not have logging. To get logging, use the "--verbose" flag.'
-				) + '\r\n'
-			);
-		}
 		switch (status) {
 			case ServerStartedStatus.JUST_STARTED: {
 				this._onDidWrite.fire(
@@ -195,7 +177,6 @@ export class ServerTaskTerminal
 	 * @param {IServerMsg} msg the log message data from the HTTP server to show in the terminal
 	 */
 	public showServerMsg(msg: IServerMsg): void {
-		if (this._verbose) {
 			const date = new Date();
 
 			this._onDidWrite.fire(
@@ -206,7 +187,6 @@ export class ServerTaskTerminal
 					TerminalColor.blue
 				)} | ${this._colorHttpStatus(msg.status)}\r\n> `
 			);
-		}
 	}
 
 	/**

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -7,7 +7,6 @@ export interface ILivePreviewConfigItem {
 	portNumber: number;
 	showServerStatusNotifications: boolean;
 	autoRefreshPreview: AutoRefreshPreview;
-	browserPreviewLaunchServerLogging: boolean;
 	openPreviewTarget: OpenPreviewTarget;
 	serverKeepAliveAfterEmbeddedPreviewClose: number;
 	notifyOnOpenLooseFile: boolean;
@@ -47,7 +46,6 @@ export const Settings: any = {
 	showStatusBarItem: 'showStatusBarItem',
 	showServerStatusNotifications: 'showServerStatusNotifications',
 	autoRefreshPreview: 'autoRefreshPreview',
-	browserPreviewLaunchServerLogging: 'tasks.browserPreviewLaunchServerLogging',
 	openPreviewTarget: 'openPreviewTarget',
 	serverKeepAliveAfterEmbeddedPreviewClose:
 		'serverKeepAliveAfterEmbeddedPreviewClose',
@@ -83,10 +81,6 @@ export class SettingUtil {
 			autoRefreshPreview: config.get<AutoRefreshPreview>(
 				Settings.autoRefreshPreview,
 				AutoRefreshPreview.onAnyChange
-			),
-			browserPreviewLaunchServerLogging: config.get<boolean>(
-				Settings.browserPreviewLaunchServerLogging,
-				true
 			),
 			openPreviewTarget: config.get<OpenPreviewTarget>(
 				Settings.openPreviewTarget,

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -96,7 +96,7 @@ export class SettingUtil {
 			),
 			runTaskWithExternalPreview: config.get<boolean>(
 				Settings.runTaskWithExternalPreview,
-				true
+				false
 			),
 			defaultPreviewPath: config.get<string>(Settings.defaultPreviewPath, ''),
 			debugOnExternalPreview: config.get<boolean>(


### PR DESCRIPTION
Fixes #307
Fixes #278
Fixes #260

- Remove the non `--verbose` option for tasks.
- tasks don't launch on default for external browser
- Other task cleanup