### PR TITLE
Enable start server from absolute/relative filename

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Preview Page 0",
+			"command": "${input:preview-args}",
+			"problemMatcher": []
+		}
+	],
+	"inputs": [
+		{
+			"id": "preview-args",
+			"type": "command",
+			"command": "livePreview.start.preview.atFileString",
+			"args": "/test-workspace/page0.html"
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "onCommand:livePreview.start.internalPreview.atFile",
     "onCommand:livePreview.start.externalPreview.atFile",
     "onCommand:livePreview.start.externalDebugPreview.atFile",
+    "onCommand:livePreview.start.preview.atFileString",
     "onTaskType:Live Preview"
   ],
   "main": "./out/extension.js",
@@ -97,6 +98,11 @@
       {
         "command": "livePreview.end",
         "title": "%commands.stopServer%",
+        "category": "%commands.category%"
+      },
+      {
+        "command": "livePreview.start.preview.atFileString",
+        "title": "%commands.startServerAtFileString%",
         "category": "%commands.category%"
       }
     ],

--- a/package.nls.json
+++ b/package.nls.json
@@ -9,6 +9,7 @@
 	"commands.openAutomaticallyOnServerStart": "Open Automatically on Server Start",
 	"commands.runServerLoggingTask": "Start Server Logging",
 	"commands.stopServer": "Stop Server",
+	"commands.startServerAtFileString": "Start Server at File Path String",
 	"settings.portNumber": "Which local port the live preview's server should try initially. If this port number doesn't work, it will increment the port number until it finds a free port.",
 	"settings.serverKeepAliveAfterEmbeddedPreviewClose": "How many minutes after closing the embedded preview you want the server to shut off. Set to 0 to have server stay on indefinetely.",
 	"settings.showServerStatusNotifications": "Whether or not to show information messages on server on/off status change.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,6 +53,17 @@ export function activate(context: vscode.ExtensionContext): void {
 		})
 	);
 
+	/**
+	 * Not used directly by the extension, but can be called by a task or another extension to open a preview at a file
+	 */
+	context.subscriptions.push(
+		vscode.commands.registerCommand(`${SETTINGS_SECTION_ID}.start.preview.atFileString`,
+			async (filePath?: string) => {
+				filePath = filePath ?? '/';
+				await serverPreview.openPreviewAtFileString(filePath);
+			})
+	);
+
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			`${SETTINGS_SECTION_ID}.start.preview.atFile`,


### PR DESCRIPTION
Fixes #388

Also added a sample tasks.json for using the command.