### PR TITLE
Add option to choose root offset for previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,10 @@
           "when": "false"
         },
         {
+          "command": "livePreview.start.preview.atFileString",
+          "when": "false"
+        },
+        {
           "command": "livePreview.start.debugPreview.atFile",
           "when": "false"
         },
@@ -244,7 +248,8 @@
         "livePreview.serverRoot": {
           "type": "string",
           "default": "",
-          "description": "%settings.serverRoot%"
+          "description": "%settings.serverRoot%",
+          "scope": "resource"
         },
         "livePreview.debugOnExternalPreview": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -241,6 +241,11 @@
           "default": "",
           "description": "%settings.defaultPreviewPath%"
         },
+        "livePreview.serverRoot": {
+          "type": "string",
+          "default": "",
+          "description": "%settings.serverRoot%"
+        },
         "livePreview.debugOnExternalPreview": {
           "type": "boolean",
           "default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,7 +19,7 @@
 	"settings.tasks.runTaskWithExternalPreview": "Whether or not to pair external preview instances with the auto-generated server task. When disabled, the server will also not automatically close (until the window is closed).",
 	"settings.defaultPreviewPath": "The file to automatically show upon starting the server. Leave blank to open at the index.",
 	"settings.debugOnExternalPreview": "Whether or not to attach the JavaScript debugger on external preview launches.",
-	"settings.serverRoot": "The server root to host the server from. Files will be previewed as if the workspace root is at this offset.",
+	"settings.serverRoot": "The server root to host the server from. Files will be previewed as if the workspace root is at this offset. If this directory path doesn't exist your workspace, it will default to the workspace root. This will not apply to the root of your drive if you are not in a workspace.",
 	"settings.hostIP": "The local IP host address to host your files on.",
 	"settings.customExternalBrowser": "The browser you want to launch when previewing a file in an external browser. Only works for normal preview (non-debug). Select `None` to use your default browser.",
 	"tasks.workspacePathDesc": "The path for the workspace that you want to start the server in."

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,6 +19,7 @@
 	"settings.tasks.runTaskWithExternalPreview": "Whether or not to pair external preview instances with the auto-generated server task. When disabled, the server will also not automatically close (until the window is closed).",
 	"settings.defaultPreviewPath": "The file to automatically show upon starting the server. Leave blank to open at the index.",
 	"settings.debugOnExternalPreview": "Whether or not to attach the JavaScript debugger on external preview launches.",
+	"settings.serverRoot": "The server root to host the server from. Files will be previewed as if the workspace root is at this offset.",
 	"settings.hostIP": "The local IP host address to host your files on.",
 	"settings.customExternalBrowser": "The browser you want to launch when previewing a file in an external browser. Only works for normal preview (non-debug). Select `None` to use your default browser.",
 	"tasks.workspacePathDesc": "The path for the workspace that you want to start the server in."

--- a/src/connectionInfo/connectionManager.ts
+++ b/src/connectionInfo/connectionManager.ts
@@ -111,11 +111,13 @@ export class ConnectionManager extends Disposable {
 	 * @returns connection
 	 */
 	public createAndAddNewConnection(
-		workspaceFolder: vscode.WorkspaceFolder | undefined
+		workspaceFolder: vscode.WorkspaceFolder | undefined,
 	): Connection {
+		const serverRootPrefix = SettingUtil.GetConfig().serverRoot;
 		const connection = this._register(
 			new Connection(
 				workspaceFolder,
+				serverRootPrefix,
 				this._initHttpPort,
 				this._initWSPort,
 				this._initHost

--- a/src/connectionInfo/connectionManager.ts
+++ b/src/connectionInfo/connectionManager.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 import { DEFAULT_HOST } from '../utils/constants';
 import { Disposable } from '../utils/dispose';
+import { PathUtil } from '../utils/pathUtil';
 import { SETTINGS_SECTION_ID, SettingUtil } from '../utils/settingsUtil';
 import { Connection, ConnectionInfo } from './connection';
 
@@ -110,10 +111,11 @@ export class ConnectionManager extends Disposable {
 	 * @param workspaceFolder
 	 * @returns connection
 	 */
-	public createAndAddNewConnection(
+	public async createAndAddNewConnection(
 		workspaceFolder: vscode.WorkspaceFolder | undefined,
-	): Connection {
-		const serverRootPrefix = SettingUtil.GetConfig().serverRoot;
+	): Promise<Connection> {
+		const serverRootPrefix = workspaceFolder ? await PathUtil.GetValidServerRootForWorkspace(workspaceFolder) : '';
+
 		const connection = this._register(
 			new Connection(
 				workspaceFolder,

--- a/src/editorPreview/browserPreview.ts
+++ b/src/editorPreview/browserPreview.ts
@@ -245,7 +245,6 @@ export class BrowserPreview extends Disposable {
 				});
 			}
 		} else {
-			const uri = vscode.Uri.parse(givenURL);
 			vscode.window
 				.showInformationMessage(
 					localize(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,8 +48,8 @@ export function activate(context: vscode.ExtensionContext): void {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand(`${SETTINGS_SECTION_ID}.start`, async () => {
-			const filePath = SettingUtil.GetConfig().defaultPreviewPath;
-			await serverPreview.openPreviewAtFileString(filePath);
+			const defaultPreviewPath = SettingUtil.GetConfig().defaultPreviewPath;
+			await serverPreview.openPreviewAtFileString(defaultPreviewPath);
 		})
 	);
 
@@ -180,12 +180,12 @@ export function activate(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			`${SETTINGS_SECTION_ID}.setDefaultOpenFile`,
-			(file: vscode.Uri) => {
+			async (file: vscode.Uri) => {
 				// Will set the path on workspace settings if workspace is open
 				// otherwise, it will set user setting.
 
 				const numWorkspaceFolders = vscode.workspace.workspaceFolders?.length ?? 0;
-				const relativePath = PathUtil.getPathRelativeToWorkspace(file);
+				const relativePath = await PathUtil.getPathRelativeToWorkspace(file);
 
 				if (relativePath) {
 					const setPath = (numWorkspaceFolders === 1) ? relativePath : file.fsPath;

--- a/src/infoManagers/endpointManager.ts
+++ b/src/infoManagers/endpointManager.ts
@@ -27,7 +27,7 @@ export class EndpointManager extends Disposable {
 		while (i < workspaceDocuments.length) {
 			if (
 				!workspaceDocuments[i].isUntitled &&
-				!PathUtil.AbsPathInAnyWorkspace(workspaceDocuments[i].fileName)
+				!PathUtil.GetWorkspaceFromAbsolutePath(workspaceDocuments[i].fileName)
 			) {
 				this.encodeLooseFileEndpoint(workspaceDocuments[i].fileName);
 			}

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -48,22 +48,7 @@ export class HttpServer extends Disposable {
 	 * @returns {string | undefined} the path where the server index is located.
 	 */
 	private get _basePath(): string | undefined {
-		return this._connection.workspacePath;
-	}
-
-	/**
-	 * @param {string} file file to check
-	 * @returns {boolean} whether the HTTP server has served `file` since last reset or beginning of extension activation.
-	 */
-	public hasServedFile(file: string): boolean {
-		if (this._contentLoader.servedFiles) {
-			for (const item of this._contentLoader.servedFiles.values()) {
-				if (PathUtil.PathEquals(file, item)) {
-					return true;
-				}
-			}
-		}
-		return false;
+		return this._connection.rootPath;
 	}
 
 	/**

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -99,7 +99,7 @@ export class WSServer extends Disposable {
 	 * @description the location of the workspace.
 	 */
 	private get _basePath(): string | undefined {
-		return this._connection.workspacePath;
+		return this._connection.rootPath;
 	}
 
 	public get wsPath(): string {

--- a/src/task/serverTaskLinkProvider.ts
+++ b/src/task/serverTaskLinkProvider.ts
@@ -193,16 +193,12 @@ export class serverTaskLinkProvider
 	 */
 	private async _openRelativeLinkInWorkspace(file: string, isDir: boolean): Promise<void> {
 		file = unescape(file);
-		const workspace = await PathUtil.PathExistsRelativeToAnyWorkspace(file);
-
-		const fullPath = workspace
-			? workspace?.uri + file
-			: 'file:///' + this._endpointManager.decodeLooseFileEndpoint(file);
-
-		const uri = vscode.Uri.parse(fullPath);
+		const workspace = await PathUtil.GetWorkspaceFromRelativePath(file);
+		const connection = this._connectionManager.getConnection(workspace);
+		const uri = connection ? connection.getAppendedURI(file) : vscode.Uri.file(await this._endpointManager.decodeLooseFileEndpoint(file) ?? '');
 
 		if (isDir) {
-			if (!PathUtil.AbsPathInAnyWorkspace(uri.fsPath)) {
+			if (!PathUtil.GetWorkspaceFromAbsolutePath(uri.fsPath)) {
 				vscode.window.showErrorMessage(
 					'Cannot reveal folder. It is not in the open workspace.'
 				);

--- a/src/updateListener.ts
+++ b/src/updateListener.ts
@@ -125,7 +125,7 @@ export class UpdateListener extends Disposable {
 	 * @param uri
 	 */
 	private _reloadIfOutOfWorkspace(uri: vscode.Uri): void {
-		if (!vscode.workspace.getWorkspaceFolder(uri)) {
+		if (!PathUtil.GetWorkspaceFromURI(uri)) {
 			this._shouldRefreshPreviews.fire();
 		}
 	}

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -20,6 +20,7 @@ export interface ILivePreviewConfigItem {
 	debugOnExternalPreview: boolean;
 	hostIP: string;
 	customExternalBrowser: CustomExternalBrowser;
+	serverRoot: string;
 }
 
 /**
@@ -67,7 +68,8 @@ export const Settings: any = {
 	defaultPreviewPath: 'defaultPreviewPath',
 	debugOnExternalPreview: 'debugOnExternalPreview',
 	hostIP: 'hostIP',
-	customExternalBrowser: 'customExternalBrowser'
+	customExternalBrowser: 'customExternalBrowser',
+	serverRoot: 'serverRoot'
 };
 
 /**
@@ -82,10 +84,10 @@ export const PreviewType = {
 export class SettingUtil {
 	/**
 	 * @description Get the current settings JSON.
-	 * @returns {ILivePreviewConfigItem} the LiveServerConfigItem, which is a JSON object with all of the settings for Live Preview.
+	 * @returns {ILivePreviewConfigItem} a JSON object with all of the settings for Live Preview.
 	 */
-	public static GetConfig(): ILivePreviewConfigItem {
-		const config = vscode.workspace.getConfiguration(SETTINGS_SECTION_ID);
+	public static GetConfig(scope?: vscode.ConfigurationScope): ILivePreviewConfigItem {
+		const config = vscode.workspace.getConfiguration(SETTINGS_SECTION_ID, scope);
 		return {
 			portNumber: config.get<number>(Settings.portNumber, 3000),
 			showServerStatusNotifications: config.get<boolean>(
@@ -119,6 +121,7 @@ export class SettingUtil {
 			),
 			hostIP: config.get<string>(Settings.hostIP, '127.0.0.1'),
 			customExternalBrowser: config.get<CustomExternalBrowser>(Settings.customExternalBrowser, CustomExternalBrowser.none),
+			serverRoot: config.get<string>(Settings.serverRoot, '')
 		};
 	}
 


### PR DESCRIPTION
Fixes #155
Fixes #408
Fixes #409

If the `serverRoot` setting is set and appending it to the current workspace makes sense (the directory path exists relative to the workspace root), then all relative paths will be relative to that server root offset.