### PR TITLE
use default external browser in web

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -21,6 +21,6 @@
 	"settings.debugOnExternalPreview": "Whether or not to attach the JavaScript debugger on external preview launches.",
 	"settings.serverRoot": "The relative path from the workspace root that the files are served from. Files will be previewed as if the workspace root is at this relative path. If this directory path doesn't exist in your workspace, it will default to the workspace root. This setting only applies if you have a workspace open.",
 	"settings.hostIP": "The local IP host address to host your files on.",
-	"settings.customExternalBrowser": "The browser you want to launch when previewing a file in an external browser. Only works for normal preview (non-debug).",
+	"settings.customExternalBrowser": "The browser you want to launch when previewing a file in an external browser. Only works for normal preview (non-debug) and only works on desktop.",
 	"tasks.workspacePathDesc": "The path for the workspace that you want to start the server in."
 }

--- a/src/utils/externalBrowserUtils.ts
+++ b/src/utils/externalBrowserUtils.ts
@@ -9,6 +9,12 @@ import * as vscode from 'vscode';
 export class ExternalBrowserUtils {
 
 	static async openInBrowser(target: string, browser: CustomExternalBrowser): Promise<void> {
+
+		if (vscode.env.appHost !== 'desktop') {
+			vscode.env.openExternal(vscode.Uri.parse(target));
+			return;
+		}
+
 		try {
 			let appName: string | readonly string[] = '';
 			switch (browser) {


### PR DESCRIPTION
Fixes #414

Codespaces can't process the calls to `open`, nor does it throw an error, so force it to use vscode API to open new window.