### PR TITLE
Add customizable debounce delay to preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,6 +208,13 @@
           "maximum": 20,
           "description": "%settings.serverKeepAliveAfterEmbeddedPreviewClose%"
         },
+        "livePreview.previewDebounceDelay": {
+          "type": "number",
+          "default": 50,
+          "minimum": 0,
+          "maximum": 65535,
+          "description": "%settings.previewDebounceDelay%"
+        },
         "livePreview.showServerStatusNotifications": {
           "type": "boolean",
           "default": false,

--- a/package.json
+++ b/package.json
@@ -212,7 +212,6 @@
           "type": "number",
           "default": 50,
           "minimum": 0,
-          "maximum": 65535,
           "description": "%settings.previewDebounceDelay%"
         },
         "livePreview.showServerStatusNotifications": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -12,6 +12,7 @@
 	"commands.startServerAtFileString": "Start Server at File Path String",
 	"settings.portNumber": "Which local port the live preview's server should try initially. If this port number doesn't work, it will increment the port number until it finds a free port.",
 	"settings.serverKeepAliveAfterEmbeddedPreviewClose": "How many minutes after closing the embedded preview you want the server to shut off. Set to 0 to have server stay on indefinetely.",
+	"settings.previewDebounceDelay": "How many milliseconds delay to use when debouncing the preview update.",
 	"settings.showServerStatusNotifications": "Whether or not to show information messages on server on/off status change.",
 	"settings.autoRefreshPreview": "How often to automatically refresh the preview.",
 	"settings.openPreviewTarget": "The preferred target for previews.",

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -21,6 +21,7 @@ export interface ILivePreviewConfigItem {
 	hostIP: string;
 	customExternalBrowser: CustomExternalBrowser;
 	serverRoot: string;
+	previewDebounceDelay: number;
 }
 
 /**
@@ -69,7 +70,8 @@ export const Settings: any = {
 	debugOnExternalPreview: 'debugOnExternalPreview',
 	hostIP: 'hostIP',
 	customExternalBrowser: 'customExternalBrowser',
-	serverRoot: 'serverRoot'
+	serverRoot: 'serverRoot',
+	previewDebounceDelay: 'previewDebounceDelay'
 };
 
 /**
@@ -105,6 +107,10 @@ export class SettingUtil {
 			serverKeepAliveAfterEmbeddedPreviewClose: config.get<number>(
 				Settings.serverKeepAliveAfterEmbeddedPreviewClose,
 				20
+			),
+			previewDebounceDelay: config.get<number>(
+				Settings.previewDebounceDelay,
+				50
 			),
 			notifyOnOpenLooseFile: config.get<boolean>(
 				Settings.notifyOnOpenLooseFile,


### PR DESCRIPTION
Fixes #174

Adds setting- `livePreview.previewDebounceDelay`, which defaults to 50 and makes things a lot smoother with lots of changes.