### PR TITLE
Fix bug when previewing UNC files and path refactoring

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -121,7 +121,6 @@
 	 * @param {string} url the URL to use to set the URL bar.
 	 */
 	function setURLBar(url) {
-		console.log('wwwwwww');
 		document.getElementById('url-input').value = decodeURI(url);
 	}
 
@@ -262,7 +261,6 @@
 			}
 			// from extension
 			case 'set-url': {
-				console.log('wooooo');
 				const msgJSON = JSON.parse(message.text);
 				// setting a new address, ensure that previous link preview is gone
 				document.getElementById('link-preview').hidden = true;
@@ -287,7 +285,6 @@
 					command: 'update-path',
 					text: message.text,
 				});
-				console.log('eeeep');
 				setURLBar(msgJSON.path.href);
 				updateState(msgJSON.path.pathname);
 

--- a/media/main.js
+++ b/media/main.js
@@ -121,6 +121,7 @@
 	 * @param {string} url the URL to use to set the URL bar.
 	 */
 	function setURLBar(url) {
+		console.log('wwwwwww');
 		document.getElementById('url-input').value = decodeURI(url);
 	}
 
@@ -261,6 +262,7 @@
 			}
 			// from extension
 			case 'set-url': {
+				console.log('wooooo');
 				const msgJSON = JSON.parse(message.text);
 				// setting a new address, ensure that previous link preview is gone
 				document.getElementById('link-preview').hidden = true;
@@ -285,6 +287,7 @@
 					command: 'update-path',
 					text: message.text,
 				});
+				console.log('eeeep');
 				setURLBar(msgJSON.path.href);
 				updateState(msgJSON.path.pathname);
 
@@ -310,8 +313,7 @@
 			// from child iframe
 			case 'open-external-link': {
 				vscode.postMessage({
-					command: 'open-browser',
-					text: message.text,
+					command: 'open-browser'
 				});
 				break;
 			}
@@ -451,8 +453,7 @@
 		document.getElementById('browser-open').addEventListener('click', () => {
 			document.getElementById('extras-menu-pane').hidden = true;
 			vscode.postMessage({
-				command: 'open-browser',
-				text: '',
+				command: 'open-browser'
 			});
 		});
 

--- a/src/connectionInfo/connection.ts
+++ b/src/connectionInfo/connection.ts
@@ -158,22 +158,6 @@ export class Connection extends Disposable {
 	}
 
 	/**
-	 * @description Checks if a file exists given its **relative** file to the workspace.
-	 *  (always returns false if undefined workspace).
-	 *  e.g. with workspace `c:/a/file/path/`, and there exists `c:/a/file/path/continued/index.html`,
-	 *  passing `path` as `/continued/index.html` will return true.
-	 * @param {string} file file to test.
-	 * @returns {boolean} whether the path exists relative the default workspace
-	 */
-	public async pathExistsRelativeToWorkspace(file: string): Promise<boolean> {
-		if (!this.rootPath) {
-			return false;
-		}
-		const fullPath = path.join(this.rootPath, file);
-		return (await PathUtil.FileExistsStat(fullPath)).exists;
-	}
-
-	/**
 	 * @description Given an absolute file, get the file relative to the workspace.
 	 *  Will return empty string if `!_absPathInWorkspace(path)`.
 	 * @param {string} path the absolute path to convert.

--- a/src/editorPreview/previewManager.ts
+++ b/src/editorPreview/previewManager.ts
@@ -209,6 +209,7 @@ export class PreviewManager extends Disposable {
 				this._extensionUri,
 				this._reporter,
 				this._connectionManager,
+				this._endpointManager,
 				this._outputChannel
 			)
 		);

--- a/src/editorPreview/webviewComm.ts
+++ b/src/editorPreview/webviewComm.ts
@@ -105,7 +105,7 @@ export class WebviewComm extends Disposable {
 	 *  can be:
 	 * 1. /relative-pathname OR (blank string) for root
 	 * 2. /c:/absolute-pathname
-	 * 3. //unc-absolute-path
+	 * 3. /unc/absolute-unc-pathname
 	 * @param {boolean} updateHistory whether or not to update the history from this call.
 	 */
 	public async goToFile(

--- a/src/infoManagers/endpointManager.ts
+++ b/src/infoManagers/endpointManager.ts
@@ -43,12 +43,13 @@ export class EndpointManager extends Disposable {
 
 		fullParent = PathUtil.ConvertToPosixPath(fullParent);
 		this.validEndpointRoots.add(fullParent);
-		fullParent = PathUtil.EscapePathParts(fullParent);
 
 		let endpoint_prefix = `/endpoint_unsaved`;
 		if ((await PathUtil.FileExistsStat(location)).exists) {
 			endpoint_prefix = this.changePrefixesForAbsPathEncode(fullParent);
 		}
+
+		endpoint_prefix = PathUtil.EscapePathParts(endpoint_prefix);
 
 		// don't use path.join so that we don't remove leading slashes
 		const ret = `${endpoint_prefix}/${child}`;
@@ -76,7 +77,7 @@ export class EndpointManager extends Disposable {
 	 * @returns {string | undefined} the filesystem path that it loads or undefined if it doesn't decode to anything.
 	 */
 	public async decodeLooseFileEndpoint(urlPath: string): Promise<string | undefined> {
-		const path = PathUtil.UnescapePathParts(this.changePrefixesForAbsPathDecode(urlPath));
+		const path = this.changePrefixesForAbsPathDecode(PathUtil.UnescapePathParts(urlPath));
 		if (this.validPath(path)) {
 			const exists = (await PathUtil.FileExistsStat(path)).exists;
 			if (exists) {
@@ -106,11 +107,15 @@ export class EndpointManager extends Disposable {
 	 */
 	public changePrefixesForAbsPathDecode(urlPath: string): string {
 		let path = urlPath;
-		if (urlPath.startsWith('/unc/')) {
-			path = `//${urlPath.substring(5)}`;
-		} else if (urlPath.startsWith('/') && urlPath.length > 1) {
+
+		if (urlPath.startsWith('/') && urlPath.length > 1) {
 			path = urlPath.substring(1);
 		}
+
+		if (urlPath.startsWith('unc/')) {
+			path = `//${urlPath.substring(4)}`;
+		}
+
 		return path;
 	}
 

--- a/src/infoManagers/endpointManager.ts
+++ b/src/infoManagers/endpointManager.ts
@@ -4,9 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from '../utils/dispose';
-import * as path from 'path';
 import { PathUtil } from '../utils/pathUtil';
-import * as fs from 'fs';
 import * as vscode from 'vscode';
 
 /**
@@ -40,20 +38,27 @@ export class EndpointManager extends Disposable {
 	 * @returns the encoded endpoint.
 	 */
 	public async encodeLooseFileEndpoint(location: string): Promise<string> {
-		const parent = await PathUtil.GetImmediateParentDir(location);
 		let fullParent = await PathUtil.GetParentDir(location);
 		const child = await PathUtil.GetFileName(location, true);
 
 		fullParent = PathUtil.ConvertToPosixPath(fullParent);
 		this.validEndpointRoots.add(fullParent);
 		fullParent = PathUtil.EscapePathParts(fullParent);
+
 		let endpoint_prefix = `/endpoint_unsaved`;
-		if (parent != '.') {
-			endpoint_prefix = `/${fullParent}`;
+		if ((await PathUtil.FileExistsStat(location)).exists) {
+			endpoint_prefix = this.changePrefixesForAbsPathEncode(fullParent);
 		}
-		return path.join(endpoint_prefix, child);
+
+		// don't use path.join so that we don't remove leading slashes
+		const ret = `${endpoint_prefix}/${child}`;
+		return ret;
 	}
 
+	/**
+	 * Get the immediate parent of the encoded endpoint path. Needed to create index pages
+	 * @param urlPath
+	 */
 	public getEndpointParent(urlPath: string): string {
 		let endpoint: string | undefined = urlPath.endsWith('/')
 			? urlPath.substr(0, urlPath.length - 1)
@@ -63,7 +68,7 @@ export class EndpointManager extends Disposable {
 		if (!endpoint || endpoint == '/endpoint_unsaved') {
 			return '.';
 		}
-		return unescape(endpoint);
+		return decodeURI(endpoint);
 	}
 
 	/**
@@ -71,7 +76,7 @@ export class EndpointManager extends Disposable {
 	 * @returns {string | undefined} the filesystem path that it loads or undefined if it doesn't decode to anything.
 	 */
 	public async decodeLooseFileEndpoint(urlPath: string): Promise<string | undefined> {
-		const path = PathUtil.UnescapePathParts(urlPath);
+		const path = PathUtil.UnescapePathParts(this.changePrefixesForAbsPathDecode(urlPath));
 		if (this.validPath(path)) {
 			const exists = (await PathUtil.FileExistsStat(path)).exists;
 			if (exists) {
@@ -92,5 +97,35 @@ export class EndpointManager extends Disposable {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Performs the prefix changes that happen when decoding an absolute file path.
+	 * Public so that the link previewer can use it to create a file URI.
+	 * @param urlPath
+	 */
+	public changePrefixesForAbsPathDecode(urlPath: string): string {
+		let path = urlPath;
+		if (urlPath.startsWith('/unc/')) {
+			path = `//${urlPath.substring(5)}`;
+		} else if (urlPath.startsWith('/') && urlPath.length > 1) {
+			path = urlPath.substring(1);
+		}
+		return path;
+	}
+
+	/**
+	 * Performs the prefix changes that happen when encoding an absolute file path.
+	 * @param urlPath
+	 */
+	private changePrefixesForAbsPathEncode(urlPath: string): string {
+		let path = `/${urlPath}`;
+
+		if (urlPath.startsWith(`//`) && urlPath.length > 2) {
+			// use `unc` to differentiate UNC paths
+			path = `/unc/${urlPath.substring(2)}`;
+		}
+
+		return path;
 	}
 }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -457,12 +457,13 @@ export class Manager extends Disposable {
 			const serverGrouping = await this._getServerGroupingFromWorkspace(
 				connection.workspace
 			);
+
 			if (!connection.rootURI) {
 				// using server grouping with undefined workspace
 				return this._openPreview(
 					internal,
 					serverGrouping,
-					vscode.Uri.file(link.path),
+					vscode.Uri.file(this._endpointManager.changePrefixesForAbsPathDecode(link.path)),
 					debug
 				);
 			}

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -169,7 +169,7 @@ export class HttpServer extends Disposable {
 			stream?.pipe(res);
 		};
 
-		if (!basePath && (URLPathName == '/' || URLPathName == '')) {
+		if (basePath === '' && (URLPathName === '/' || URLPathName === '')) {
 			writePageNotFound(true);
 			return;
 		}

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -156,8 +156,9 @@ export class HttpServer extends Disposable {
 
 		// start processing URL
 
-		const writePageNotFound = (): void => {
-			const respInfo =
+		const writePageNotFound = (noServerRoot = false): void => {
+			const respInfo = noServerRoot ?
+				this._contentLoader.createNoRootServer() :
 				this._contentLoader.createPageDoesNotExist(absoluteReadPath);
 			res.writeHead(404, {
 				'Accept-Ranges': 'bytes',
@@ -167,6 +168,11 @@ export class HttpServer extends Disposable {
 			stream = respInfo.Stream;
 			stream?.pipe(res);
 		};
+
+		if (!basePath && (URLPathName == '/' || URLPathName == '')) {
+			writePageNotFound(true);
+			return;
+		}
 
 		let looseFile = false;
 		URLPathName = decodeURI(URLPathName);

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -47,8 +47,8 @@ export class HttpServer extends Disposable {
 	/**
 	 * @returns {string | undefined} the path where the server index is located.
 	 */
-	private get _basePath(): string | undefined {
-		return this._connection.rootPath;
+	private get _basePath(): string {
+		return this._connection.rootPath ?? '';
 	}
 
 	/**
@@ -108,12 +108,12 @@ export class HttpServer extends Disposable {
 
 	/**
 	 * @description contains the logic for content serving.
-	 * @param {string | undefined} basePath the path where the server index is located.
+	 * @param {string} basePath the path where the server index is located.
 	 * @param {http.IncomingMessage} req the request received
 	 * @param {http.ServerResponse} res the response to be loaded
 	 */
 	private async _serveStream(
-		basePath: string | undefined,
+		basePath: string,
 		req: http.IncomingMessage,
 		res: http.ServerResponse
 	): Promise<void> {
@@ -136,7 +136,7 @@ export class HttpServer extends Disposable {
 		}
 
 		let stream: Stream.Readable | fs.ReadStream | undefined;
-		if (req.url == INJECTED_ENDPOINT_NAME) {
+		if (req.url === INJECTED_ENDPOINT_NAME) {
 			const respInfo = this._contentLoader.loadInjectedJS();
 			const contentType = respInfo.ContentType ?? '';
 			res.writeHead(200, {
@@ -153,25 +153,27 @@ export class HttpServer extends Disposable {
 		);
 
 		let URLPathName = urlObj.path;
-		if (!basePath && (URLPathName == '/' || URLPathName == '')) {
-			const respInfo = this._contentLoader.createNoRootServer();
+
+		// start processing URL
+
+		const writePageNotFound = (): void => {
+			const respInfo =
+				this._contentLoader.createPageDoesNotExist(absoluteReadPath);
 			res.writeHead(404, {
 				'Accept-Ranges': 'bytes',
 				'Content-Type': respInfo.ContentType,
 			});
 			this._reportStatus(req, res);
 			stream = respInfo.Stream;
-
 			stream?.pipe(res);
-			return;
-		}
+		};
 
 		let looseFile = false;
 		URLPathName = decodeURI(URLPathName);
-		let absoluteReadPath = path.join(basePath ?? '', URLPathName);
+		let absoluteReadPath = path.join(basePath, URLPathName);
 
 		let contentType = 'application/octet-stream';
-		if (!basePath) {
+		if (basePath === '') {
 			if (URLPathName.startsWith('/endpoint_unsaved')) {
 				const untitledFileName = URLPathName.substr(
 					URLPathName.lastIndexOf('/') + 1
@@ -192,16 +194,17 @@ export class HttpServer extends Disposable {
 				}
 			}
 
-			if (!(await PathUtil.FileExistsStat(absoluteReadPath)).exists) {
-				const decodedReadPath =
-					await this._endpointManager.decodeLooseFileEndpoint(URLPathName);
-				looseFile = true;
-				if (
-					decodedReadPath &&
-					(await PathUtil.FileExistsStat(decodedReadPath)).exists
-				) {
-					absoluteReadPath = decodedReadPath;
-				}
+			const decodedReadPath =
+				await this._endpointManager.decodeLooseFileEndpoint(URLPathName);
+			looseFile = true;
+			if (
+				decodedReadPath &&
+				(await PathUtil.FileExistsStat(decodedReadPath)).exists
+			) {
+				absoluteReadPath = decodedReadPath;
+			} else {
+				writePageNotFound();
+				return;
 			}
 		} else if (!PathUtil.PathBeginsWith(absoluteReadPath, basePath)) {
 			// double-check that we aren't serving parent files.
@@ -211,17 +214,10 @@ export class HttpServer extends Disposable {
 			absoluteReadPath = basePath;
 		}
 
+		// path should be valid now
 		const absPathExistsStatInfo = await PathUtil.FileExistsStat(absoluteReadPath);
 		if (!absPathExistsStatInfo.exists) {
-			const respInfo =
-				this._contentLoader.createPageDoesNotExist(absoluteReadPath);
-			res.writeHead(404, {
-				'Accept-Ranges': 'bytes',
-				'Content-Type': respInfo.ContentType,
-			});
-			this._reportStatus(req, res);
-			stream = respInfo.Stream;
-			stream?.pipe(res);
+			writePageNotFound();
 			return;
 		}
 		if (absPathExistsStatInfo.stat && absPathExistsStatInfo.stat.isDirectory()) {

--- a/src/server/serverUtils/contentLoader.ts
+++ b/src/server/serverUtils/contentLoader.ts
@@ -140,6 +140,37 @@ export class ContentLoader extends Disposable {
 	}
 
 	/**
+	 * @description In a multi-root case, the index will not lead to anything. Create this page to list all possible indices to visit.
+	 * @returns {IRespInfo} the response info
+	 */
+	public createNoRootServer(): IRespInfo {
+		const noServerRoot = localize('noServerRoot', 'No Server Root');
+		const noWorkspaceOpen = localize(
+			'noWorkspaceOpen',
+			'This server is not based inside of a workspace, so the index does not direct to anything.'
+		);
+		const customMsg = `<p>${noWorkspaceOpen}</p>`;
+		const htmlString = `
+		<!DOCTYPE html>
+		<html>
+			<head>
+				<title>${noServerRoot}</title>
+			</head>
+			<body>
+				<h1>${noServerRoot}</h1>
+				${customMsg}
+			</body>
+			${this._scriptInjection}
+		</html>
+		`;
+
+		return {
+			Stream: Stream.Readable.from(htmlString),
+			ContentType: 'text/html; charset=UTF-8',
+		};
+	}
+
+	/**
 	 * @description Create a defaut index page (served if no `index.html` file is available for the directory).
 	 * @param {string} readPath the absolute path visited.
 	 * @param {string} relativePath the relative path (from workspace root).

--- a/src/server/serverUtils/contentLoader.ts
+++ b/src/server/serverUtils/contentLoader.ts
@@ -140,37 +140,6 @@ export class ContentLoader extends Disposable {
 	}
 
 	/**
-	 * @description In a multi-root case, the index will not lead to anything. Create this page to list all possible indices to visit.
-	 * @returns {IRespInfo} the response info
-	 */
-	public createNoRootServer(): IRespInfo {
-		const noServerRoot = localize('noServerRoot', 'No Server Root');
-		const noWorkspaceOpen = localize(
-			'noWorkspaceOpen',
-			'This server is not based inside of a workspace, so the index does not direct to anything.'
-		);
-		const customMsg = `<p>${noWorkspaceOpen}</p>`;
-		const htmlString = `
-		<!DOCTYPE html>
-		<html>
-			<head>
-				<title>${noServerRoot}</title>
-			</head>
-			<body>
-				<h1>${noServerRoot}</h1>
-				${customMsg}
-			</body>
-			${this._scriptInjection}
-		</html>
-		`;
-
-		return {
-			Stream: Stream.Readable.from(htmlString),
-			ContentType: 'text/html; charset=UTF-8',
-		};
-	}
-
-	/**
 	 * @description Create a defaut index page (served if no `index.html` file is available for the directory).
 	 * @param {string} readPath the absolute path visited.
 	 * @param {string} relativePath the relative path (from workspace root).

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -243,7 +243,7 @@ export class WSServer extends Disposable {
 			// no op
 		}
 
-		if (!(await PathUtil.FileExistsStat(absolutePath)).exists) {
+		if (!basePath) {
 			const decodedLocation =
 				await this._endpointManager.decodeLooseFileEndpoint(absolutePath);
 			if (!decodedLocation || !(await PathUtil.FileExistsStat(decodedLocation)).exists) {

--- a/src/server/wsServer.ts
+++ b/src/server/wsServer.ts
@@ -245,7 +245,7 @@ export class WSServer extends Disposable {
 
 		if (!basePath) {
 			const decodedLocation =
-				await this._endpointManager.decodeLooseFileEndpoint(absolutePath);
+				await this._endpointManager.decodeLooseFileEndpoint(PathUtil.ConvertToPosixPath(absolutePath));
 			if (!decodedLocation || !(await PathUtil.FileExistsStat(decodedLocation)).exists) {
 				// shows file not found page, which is injectable
 				return { injectable: true, pathname: url.pathname, port };

--- a/src/utils/pathUtil.ts
+++ b/src/utils/pathUtil.ts
@@ -25,7 +25,6 @@ export class PathUtil {
 		const parts = file.split('/');
 
 		const newParts = parts
-			.filter((part) => part.length > 0)
 			.map((filterdPart) => encodeURI(filterdPart));
 		return newParts.join('/');
 	}
@@ -38,7 +37,6 @@ export class PathUtil {
 	public static UnescapePathParts(file: string): string {
 		const parts = file.split('/');
 		const newParts = parts
-			.filter((part) => part.length > 0)
 			.map((filterdPart) => decodeURI(filterdPart));
 		return newParts.join('/');
 	}
@@ -55,14 +53,6 @@ export class PathUtil {
 			return file;
 		}
 		return path.dirname(file);
-	}
-
-	/**
-	 * @param {string} file a file path.
-	 * @returns {string} The most immediate parent director for the file; e.g. `c:/a/file/path.txt` returns `file`.
-	 */
-	public static async GetImmediateParentDir(file: string): Promise<string | undefined> {
-		return (await PathUtil.GetParentDir(file)).split(this._pathSepRegex).pop();
 	}
 
 	/**
@@ -104,6 +94,8 @@ export class PathUtil {
 	 * @returns {string} the file path using the `/` posix-compliant path delimeter.
 	 */
 	public static ConvertToPosixPath(file: string): string {
+
+
 		return file.split(path.sep).join(path.posix.sep);
 	}
 

--- a/src/utils/pathUtil.ts
+++ b/src/utils/pathUtil.ts
@@ -25,6 +25,7 @@ export class PathUtil {
 		const parts = file.split('/');
 
 		const newParts = parts
+			.filter((part) => part.length > 0)
 			.map((filterdPart) => encodeURI(filterdPart));
 		return newParts.join('/');
 	}
@@ -37,6 +38,7 @@ export class PathUtil {
 	public static UnescapePathParts(file: string): string {
 		const parts = file.split('/');
 		const newParts = parts
+			.filter((part) => part.length > 0)
 			.map((filterdPart) => decodeURI(filterdPart));
 		return newParts.join('/');
 	}

--- a/src/utils/pathUtil.ts
+++ b/src/utils/pathUtil.ts
@@ -96,8 +96,6 @@ export class PathUtil {
 	 * @returns {string} the file path using the `/` posix-compliant path delimeter.
 	 */
 	public static ConvertToPosixPath(file: string): string {
-
-
 		return file.split(path.sep).join(path.posix.sep);
 	}
 


### PR DESCRIPTION
Fixes #326
Fixes #444 
Cleaning up a lot of hacky path mangling.

UNC paths will look like this:
<img width="336" alt="image" src="https://user-images.githubusercontent.com/31675041/215918064-c18cd8ba-2ca9-4228-9a24-4f8f27cfba00.png">

Using slashes or encodings of slashes (ie: `%5C%5C`) causes complicated path handling when browsers automatically simplify the path, so I'm using a special endpoint (`/unc`) to deal with UNC paths.