### PR TITLE
Use active workspace when using `livePreview.start`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,10 +52,17 @@ export function activate(context: vscode.ExtensionContext): void {
 			const activeFile = vscode.window.activeTextEditor?.document.uri;
 			const activeWorkspace = activeFile ? vscode.workspace.getWorkspaceFolder(activeFile) : vscode.workspace.workspaceFolders?.[0];
 
-			// if multiple workspaces are open, use the first one
-			const defaultPreviewPath = SettingUtil.GetConfig(activeWorkspace).defaultPreviewPath;
+			// use the active workspace folder. otherwise, use the first workspace folder.
+			let defaultPreviewPath = SettingUtil.GetConfig(activeWorkspace).defaultPreviewPath;
+
+			// if this gave no results, still try to use the the preview path from other settings, but appended to the active workspace
+			// otherwise, still use the active workspace, but with no default path.
+			if (defaultPreviewPath === '') {
+				defaultPreviewPath = SettingUtil.GetConfig().defaultPreviewPath;
+			}
+
 			// defaultPreviewPath is relative to the workspace root, regardless of what is set for serverRoot
-			await serverPreview.openPreviewAtFileString(defaultPreviewPath, undefined, true);
+			await serverPreview.openPreviewAtFileString(defaultPreviewPath, undefined, activeWorkspace, true);
 		})
 	);
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -384,12 +384,13 @@ export class Manager extends Disposable {
 			return;
 		}
 
+		// no workspace, try to open as a loose file
 		if ((await PathUtil.FileExistsStat(filePath)).exists) {
 			const file = vscode.Uri.file(filePath);
 			this.openPreviewAtFileUri(file, undefined, previewType);
 		} else {
 			vscode.window.showWarningMessage(
-				localize('fileDNE', "The file '{0}' does not exist.", filePath)
+				localize('fileDNE', "The file '{0}' does not exist relative your filesystem root.", filePath)
 			);
 			this.openPreviewAtFileUri(undefined, undefined, previewType);
 		}

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -370,11 +370,12 @@ export class Manager extends Disposable {
 	 * This is usually used for when the user configures a setting for initial filepath
 	 * @param filePath the string fsPath to use
 	 */
-	public async openPreviewAtFileString(filePath: string, previewType?: string, ignoreFileRoot = false): Promise<void> {
-		if (filePath === '') {
+	public async openPreviewAtFileString(filePath: string, previewType?: string, activeWorkspace?: vscode.WorkspaceFolder, ignoreFileRoot = false): Promise<void> {
+		if (filePath === '' && !activeWorkspace) {
 			return this._openPreviewWithNoTarget();
 		}
-		const workspace = await PathUtil.GetWorkspaceFromRelativePath(filePath, ignoreFileRoot);
+
+		const workspace = activeWorkspace ? activeWorkspace : await PathUtil.GetWorkspaceFromRelativePath(filePath, ignoreFileRoot);
 		if (workspace) {
 			const file = vscode.Uri.joinPath(workspace.uri, ignoreFileRoot ? '' : await PathUtil.GetValidServerRootForWorkspace(workspace), filePath);
 			this.openPreviewAtFileUri(file, {
@@ -659,7 +660,9 @@ export class Manager extends Disposable {
 		return previewType === PreviewType.internalPreview;
 	}
 	private async _openPreviewWithNoTarget(): Promise<void> {
-		// opens index at first open server or opens a loose workspace at root
+		// Opens index at first open server or opens a loose workspace at root.
+		// This function is called with the assumption that there might be an open server already
+		// and we should check.
 
 		const internal = this._isInternalPreview();
 		const workspaces = vscode.workspace.workspaceFolders;


### PR DESCRIPTION
Fixes #455