### PR TITLE
fix console line number in external browser

### DIFF
--- a/media/injectScript.js
+++ b/media/injectScript.js
@@ -17,15 +17,17 @@ document.addEventListener('DOMContentLoaded', function (e) {
 	onLoad();
 });
 
-console.error = createConsoleOverride('ERROR');
+if (window.parent !== window) {
+	console.error = createConsoleOverride('ERROR');
 
-console.log = createConsoleOverride('LOG');
+	console.log = createConsoleOverride('LOG');
 
-console.warn = createConsoleOverride('WARN');
+	console.warn = createConsoleOverride('WARN');
 
-console.info = createConsoleOverride('INFO');
+	console.info = createConsoleOverride('INFO');
 
-console.clear = createConsoleOverride('CLEAR');
+	console.clear = createConsoleOverride('CLEAR');
+}
 
 /**
  * @description run initialization on load.


### PR DESCRIPTION
#449

Fixes https://github.com/microsoft/vscode-livepreview/issues/508

What `createConsoleOverride` does is just to call `postParentMessage` before calling console output methods, but if `window.parent === window` `postParentMessage` does nothing, so should we override console only if `window.parent !== window`? At least this fixes the issue in external browser.