### PR TITLE
Codespaces 401

### DIFF
--- a/src/connectionInfo/connection.ts
+++ b/src/connectionInfo/connection.ts
@@ -96,8 +96,8 @@ export class Connection extends Disposable {
 	 * @returns {Promise<vscode.Uri>} a promise for the WS URI
 	 */
 	public async resolveExternalWSUri(): Promise<vscode.Uri> {
-		const wsPortUri = this.constructLocalUri(this.wsPort, this.wsPath);
-		return vscode.env.asExternalUri(wsPortUri);
+		const wsPortUri = this.constructLocalUri(this.wsPort);
+		return vscode.Uri.joinPath(await vscode.env.asExternalUri(wsPortUri),this.wsPath); // ensure that this pathname is retained, as the websocket server must see this in order to authorize
 	}
 
 	/**

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -159,7 +159,7 @@ export class HttpServer extends Disposable {
 		const expectedUri = await this._connection.resolveExternalHTTPUri();
 		const expectedHost = expectedUri.authority;
 		if (
-			(req.headers.host !== 'localhost' &&
+			(req.headers.host !== `localhost:${this._connection.httpPort}` &&
 				req.headers.host !== this._connection.host &&
 				req.headers.host !== expectedHost) ||
 			(req.headers.origin &&


### PR DESCRIPTION
Fixes #546

Seems that codespaces might have changed how the host header looked from what it was when https://github.com/microsoft/vscode-livepreview/pull/366 was implemented.