### PR TITLE
use public npm registry in prerelease

### DIFF
--- a/build/pre-release.yml
+++ b/build/pre-release.yml
@@ -27,6 +27,7 @@ parameters:
 extends:
   template: azure-pipelines/extension/pre-release.yml@templates
   parameters:
+    customNPMRegistry: ''
     l10nSourcePaths: ./src
     buildSteps:
       - script: yarn install --frozen-lockfile


### PR DESCRIPTION
To mitigate the 401 error in downloading mime package in prerelease pipeline