### PR TITLE
fix: Connection.resolveExternalWSUri should return ws or wss schema

### DIFF
--- a/src/connectionInfo/connection.ts
+++ b/src/connectionInfo/connection.ts
@@ -102,8 +102,10 @@ export class Connection extends Disposable {
 		if (!wsPath) {
 			wsPath = this.wsPath;
 		}
-		const wsPortUri = this.constructLocalUri(wsPort);
-		return vscode.Uri.joinPath(await vscode.env.asExternalUri(wsPortUri),wsPath); // ensure that this pathname is retained, as the websocket server must see this in order to authorize
+		const httpPortUri = this.constructLocalUri(wsPort);
+		const externalHttpUri = await vscode.env.asExternalUri(httpPortUri);
+		const externalWsUri = externalHttpUri.with({scheme : externalHttpUri.scheme === 'https' ? 'wss' : 'ws'});
+		return vscode.Uri.joinPath(externalWsUri, wsPath); // ensure that this pathname is retained, as the websocket server must see this in order to authorize
 	}
 
 	/**

--- a/src/editorPreview/webviewComm.ts
+++ b/src/editorPreview/webviewComm.ts
@@ -132,7 +132,7 @@ export class WebviewComm extends Disposable {
 		this._panel.webview.html = this._getHtmlForWebview(
 			webview,
 			url,
-			`ws://${wsURI.authority}${wsURI.path}`,
+			`${wsURI.scheme}://${wsURI.authority}${wsURI.path}`,
 			`${httpHost.scheme}://${httpHost.authority}`
 		);
 

--- a/src/server/serverUtils/HTMLInjector.ts
+++ b/src/server/serverUtils/HTMLInjector.ts
@@ -75,9 +75,7 @@ export class HTMLInjector extends Disposable {
 			wsUri = await this._connection.resolveExternalWSUri();
 		}
 
-		// if the HTTP scheme uses SSL, the WS scheme must also use SSL
-		const wsURL = `${httpUri.scheme === 'https' ? 'wss' : 'ws'}://${wsUri.authority
-			}${wsUri.path}`;
+		const wsURL = `${wsUri.scheme}://${wsUri.authority}${wsUri.path}`;
 		let httpURL = `${httpUri.scheme}://${httpUri.authority}`;
 
 		if (httpURL.endsWith('/')) {

--- a/src/test/suite/connectionInfo.test.ts
+++ b/src/test/suite/connectionInfo.test.ts
@@ -55,7 +55,7 @@ describe('ConnectionInfo', () => {
 
 		assert.ok(target.calledOnce);
 		const httpUri = vscode.Uri.parse('http://127.0.0.1:3000');
-		const wsUri = vscode.Uri.parse('http://127.0.0.1:3001/1234');
+		const wsUri = vscode.Uri.parse('ws://127.0.0.1:3001/1234');
 		assert.deepStrictEqual([
 			{
 				httpURI: httpUri,
@@ -103,7 +103,7 @@ describe('ConnectionInfo', () => {
 		await connection.connected();
 		assert(connection.workspace === undefined);
 		const httpUri = vscode.Uri.parse('http://127.0.0.1:3000');
-		const wsUri = vscode.Uri.parse('http://127.0.0.1:3001/1234');
+		const wsUri = vscode.Uri.parse('ws://127.0.0.1:3001/1234');
 
 		assert.ok(target.calledOnce);
 		assert.deepStrictEqual([


### PR DESCRIPTION
Modifies the behavior `Connection.resolveExternalWSUri`  so that it returns as URI with a "ws" or "wss" scheme.

This avoids the need for callers of this function to correct the scheme in the results.  Most importantly in the `WebviewComm` the scheme was always replaced with a "ws" scheme, resulting in errors like

```
Mixed Content: The page at 'https://example.com' was loaded over HTTPS, but attempted to connect to the insecure WebSocket endpoint 'ws://example.com'. This request has been blocked; this endpoint must be available over WSS.
```

in secure contexts.

No other clients of the Connection class seem to rely on the behavior of returning an "http" or "https" schema.