### PR TITLE
Fix: Live Preview does not resolve file when html extension is not provided

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -38,3 +38,5 @@ export const LIVE_PREVIEW_SERVER_ON = 'LivePreviewServerOn';
 export const TASK_TERMINAL_BASE_NAME = vscode.l10n.t('Run Server');
 
 export const DEFAULT_HTTP_HEADERS = { 'Accept-Ranges': 'bytes' };
+
+export const DEFAULT_PATH_EXTENSIONS = [ '.html', '.htm' ];

--- a/src/utils/settingsUtil.ts
+++ b/src/utils/settingsUtil.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { DEFAULT_HTTP_HEADERS } from './constants';
+import { DEFAULT_HTTP_HEADERS, DEFAULT_PATH_EXTENSIONS } from './constants';
 
 /**
  * @description the object representation of the extension settings.
@@ -24,6 +24,7 @@ export interface ILivePreviewConfigItem {
 	serverRoot: string;
 	previewDebounceDelay: number;
 	httpHeaders: any;
+	pathExtensions: string[];
 }
 
 /**
@@ -74,7 +75,8 @@ export const Settings: any = {
 	customExternalBrowser: 'customExternalBrowser',
 	serverRoot: 'serverRoot',
 	previewDebounceDelay: 'previewDebounceDelay',
-	httpHeaders: 'httpHeaders'
+	httpHeaders: 'httpHeaders',
+	pathExtensions: 'pathExtensions'
 };
 
 /**
@@ -132,6 +134,7 @@ export class SettingUtil {
 			customExternalBrowser: config.get<CustomExternalBrowser>(Settings.customExternalBrowser, CustomExternalBrowser.default),
 			serverRoot: config.get<string>(Settings.serverRoot, ''),
 			httpHeaders: config.get<any>(Settings.httpHeaders, DEFAULT_HTTP_HEADERS),
+			pathExtensions: config.get<string[]>(Settings.pathExtensions, DEFAULT_PATH_EXTENSIONS),
 		};
 	}
 


### PR DESCRIPTION
Updates `HttpServer._serveStream` to check a set of whitelisted path extensions when the original path is not found.

This fixes #611 as originally stated, and also allows users to support additional extensions relevant to their own project. It also allows users to disable the feature by assigning an empty list in the settings, in case the behavior is unwanted.

Adds a new setting to configure the extension whitelist, which defaults to '.html' and '.htm'