### PR TITLE
Preserve xhtml contentType for injected content

### DIFF
--- a/src/server/serverUtils/contentLoader.ts
+++ b/src/server/serverUtils/contentLoader.ts
@@ -301,7 +301,7 @@ export class ContentLoader extends Disposable {
 
 				if (workspaceDocuments[i].languageId == 'html') {
 					fileContents = this._injectIntoFile(fileContents);
-					contentType = 'text/html';
+					contentType = contentType.includes('html') ? contentType : 'text/html';
 				}
 
 				const fileContentsBuffer = Buffer.from(fileContents);


### PR DESCRIPTION
Preserves `application/xhtml+xml` content type for `.xhtml` files when injecting content.

Resolves #688