### PR TITLE
Update webviewComm.ts iframe to allow clipboard api

### DIFF
--- a/src/editorPreview/webviewComm.ts
+++ b/src/editorPreview/webviewComm.ts
@@ -311,7 +311,7 @@ export class WebviewComm extends Disposable {
 					</div>
 				</div>
 				<div class="content">
-					<iframe id="hostedContent" src="${httpURL}"></iframe>
+					<iframe id="hostedContent" src="${httpURL}" allow="clipboard-read clipboard-write"></iframe>
 				</div>
 			</div>
 			<div id="link-preview"></div>


### PR DESCRIPTION
When using live preview, it's not possible to copy and paste the preview content.

This was due to the `iframe` created by [`webviewComm`](https://github.com/microsoft/vscode-livepreview/blob/4534410e2f2bd26526aae444773647cad1ed1c8f/src/editorPreview/webviewComm.ts#L314) not including the appropriate `allow` attribute permissions for the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API).

This change updates the `iframe` to include `clipboard-read` and `clipboard-write` permissions, allowing users to copy and paste from the preview.