### PR TITLE
Fix malformed Live Preview URL construction

### DIFF
--- a/src/connectionInfo/connection.ts
+++ b/src/connectionInfo/connection.ts
@@ -157,7 +157,8 @@ export class Connection extends Disposable {
 		const workspaceRoot = this.rootPath;
 
 		if (workspaceRoot && this._absPathInWorkspace(path)) {
-			return PathUtil.ConvertToPosixPath(path.substring(workspaceRoot.length));
+			const relativePath = PathUtil.ConvertToPosixPath(path.substring(workspaceRoot.length));
+			return relativePath.startsWith('/') || relativePath === '' ? relativePath : `/${relativePath}`;
 		} else {
 			return undefined;
 		}

--- a/src/editorPreview/webviewComm.ts
+++ b/src/editorPreview/webviewComm.ts
@@ -86,6 +86,10 @@ export class WebviewComm extends Disposable {
 		hostURI?: vscode.Uri,
 		windowId?: number | undefined,
 	): Promise<string> {
+		if (/^https?:\/\//i.test(URLExt)) {
+			return URLExt;
+		}
+
 		if (URLExt.length > 0 && URLExt[0] == '/') {
 			URLExt = URLExt.substring(1);
 		}

--- a/src/test/suite/connectionInfo.test.ts
+++ b/src/test/suite/connectionInfo.test.ts
@@ -5,6 +5,7 @@
 import assert from 'assert';
 import sinon from 'sinon';
 import vscode from 'vscode';
+import { Connection } from '../../connectionInfo/connection';
 import { ConnectionManager } from '../../connectionInfo/connectionManager';
 import { PathUtil } from '../../utils/pathUtil';
 
@@ -87,6 +88,14 @@ describe('ConnectionInfo', () => {
 	});
 
 
+	it('should include a leading slash when workspace root already ends with a separator', () => {
+		const connection = new Connection(testWorkspaces[0], '', 3000, 3001, '127.0.0.1');
+		sandbox.stub(connection, 'rootPath').get(() => 'C:\\Users\\TestUser\\workspace1\\');
+
+		assert.deepEqual(connection.getFileRelativeToWorkspace('C:\\Users\\TestUser\\workspace1\\index.html'), '/index.html');
+
+		connection.dispose();
+	});
 	it('should be able to create a Connection with an undefined workspace', async () => {
 		const target = sinon.spy();
 		sandbox.stub(SettingUtil, 'GetConfig').returns(makeSetting({}));

--- a/src/test/suite/preview.test.ts
+++ b/src/test/suite/preview.test.ts
@@ -95,4 +95,12 @@ describe('PreviewManager', () => {
 		assert.ok(executeCommand.calledOnce);
 		assert.ok(executeCommand.getCall(0).calledWith('extension.js-debug.debugLink', `http://${connection.host}:${connection.httpPort}/index.html`));
 	});
+
+	it("does not prefix absolute URLs with the preview host", async () => {
+		const webviewComm = Object.create(WebviewComm.prototype) as WebviewComm;
+		const hostUri = vscode.Uri.parse(`http://${connection.host}:${connection.httpPort}/`);
+
+		assert.equal(await webviewComm.constructAddress('http://example.test/page.html', connection, hostUri), 'http://example.test/page.html');
+		assert.equal(await webviewComm.constructAddress('https://example.test/page.html', connection, hostUri), 'https://example.test/page.html');
+	});
 });


### PR DESCRIPTION
## Summary
- Preserve absolute `http://` and `https://` URLs passed to `WebviewComm.constructAddress` instead of prefixing them with the Live Preview host.
- Ensure workspace-relative preview paths include a leading `/` when the workspace root already ends with a path separator.
- Add regression coverage for both malformed URL cases.

Fixes #840.

## Verification
- `npm run compile`
- `git diff --check`

## Note
`npm test -- --grep "leading slash|absolute URLs"` currently fails before Mocha starts in my Windows environment because the downloaded VS Code test archive rejects the CLI flags passed by the test runner, for example `--disable-extensions`, `--extensionTestsPath`, and `--extensionDevelopmentPath`.