### PR TITLE
Fix directory-index links using native path.join instead of path.posix.join

### DIFF
--- a/src/server/serverUtils/contentLoader.ts
+++ b/src/server/serverUtils/contentLoader.ts
@@ -206,7 +206,7 @@ export class ContentLoader extends Disposable {
 		}
 
 		for (const childFile of childFiles) {
-			const relativeFileWithChild = path.join(relativePath, childFile);
+			const relativeFileWithChild = path.posix.join(relativePath, childFile);
 			const absolutePath = path.join(readPath, childFile);
 
 			const fileStats = (await PathUtil.FileExistsStat(absolutePath)).stat;

--- a/src/test/suite/contentLoader.test.ts
+++ b/src/test/suite/contentLoader.test.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import assert from 'assert';
+import sinon from 'sinon';
+import vscode from 'vscode';
+import fs from 'fs';
+import { ContentLoader } from '../../server/serverUtils/contentLoader';
+import { PathUtil } from '../../utils/pathUtil';
+import { EndpointManager } from '../../infoManagers/endpointManager';
+import { ConnectionManager } from '../../connectionInfo/connectionManager';
+import { Connection } from '../../connectionInfo/connection';
+import { MockTelemetryReporter } from './mocks/mockTelemetryReporter';
+import { testWorkspaces } from './common';
+
+async function streamToString(stream: NodeJS.ReadableStream | undefined): Promise<string> {
+	if (!stream) return '';
+	const chunks: Buffer[] = [];
+	for await (const chunk of stream) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return Buffer.concat(chunks).toString('utf8');
+}
+
+describe('ContentLoader.createIndexPage', () => {
+	let sandbox: sinon.SinonSandbox;
+	let contentLoader: ContentLoader;
+	let telemetryReporter: MockTelemetryReporter;
+	let connection: Connection;
+
+	before(async () => {
+		sandbox = sinon.createSandbox();
+		const extensionUri = vscode.Uri.file('c:/Users/TestUser/vscode-livepreview/');
+		telemetryReporter = new MockTelemetryReporter();
+		const connectionManager = new ConnectionManager();
+		connection = await connectionManager.createAndAddNewConnection(testWorkspaces[0]);
+		const endpointManager = new EndpointManager();
+
+		contentLoader = new ContentLoader(extensionUri, telemetryReporter, endpointManager, connection);
+
+		sandbox.stub(ContentLoader.prototype, <any>'fsReadDir').returns(Promise.resolve(['folder', 'anotherfolder']));
+		sandbox.stub(PathUtil, 'FileExistsStat').callsFake((_path: string) => {
+			// Every entry fsReadDir returns is reported as a directory, and
+			// none of them has an index.html, matching the bug report's
+			// workspace shape (two plain subfolders, no index files).
+			return Promise.resolve({ exists: true, stat: { isDirectory: () => true } as unknown as fs.Stats });
+		});
+	});
+
+	after(() => {
+		contentLoader.dispose();
+		telemetryReporter.dispose();
+		sandbox.restore();
+	});
+
+	// Regression test for the bug reported in #855: on Windows,
+	// path.join('/apps', 'folder') returns '\apps\folder' (native
+	// separators), which encodeURI then turns into '%5Capps%5Cfolder'
+	// instead of a working relative link. The fix uses path.posix.join for
+	// the link href specifically, which always returns forward slashes
+	// regardless of host OS -- see the equivalent standalone reproduction
+	// in the PR description using path.win32.join vs path.posix.join
+	// directly, which is what actually demonstrates the before/after
+	// difference (this suite runs on whatever OS CI uses, so it can't
+	// force the native-separator branch to differ here the way a real
+	// Windows host does).
+	it('generates directory links with forward slashes, not encoded backslashes', async () => {
+		const respInfo = await contentLoader.createIndexPage('c:/Users/TestUser/workspace1/apps', '/apps');
+		const html = await streamToString(respInfo.Stream as unknown as NodeJS.ReadableStream);
+
+		assert.ok(!html.includes('%5C') && !html.includes('%5c'), `expected no encoded backslashes in:\n${html}`);
+		assert.ok(html.includes('href="/apps/folder/"'), `expected a working /apps/folder/ link in:\n${html}`);
+		assert.ok(html.includes('href="/apps/anotherfolder/"'), `expected a working /apps/anotherfolder/ link in:\n${html}`);
+	});
+});


### PR DESCRIPTION
Fixes #855 (and the same root cause as #762, #795).

## The bug

`createIndexPage()` builds each directory-listing link with:
```ts
const relativeFileWithChild = path.join(relativePath, childFile);
```
`path.join` uses the host OS's native path separator. `relativePath` here is always a URL path (it comes from the decoded request URL, not a filesystem path), but on Windows `path.join` still returns `\`-separated output — e.g. `path.join('/apps', 'folder')` → `\apps\folder`. That string is then passed through `encodeURI()`, which percent-encodes the backslashes, producing exactly the broken links reported: `%5Capps%5Cfolder`.

## The fix

Use `path.posix.join` for that one join — it always returns `/`-separated output regardless of host OS, which is what a URL path segment actually needs. The sibling `absolutePath` join on the next line is untouched, since that one is a real filesystem path and correctly needs native separators.

## Verification

**Exact reproduction of the reported bug**, using Node's own platform-specific path modules directly (no Windows machine needed — `path.win32`/`path.posix` are both available cross-platform for exactly this):
```
$ node -e "
const path = require('path');
console.log(encodeURI(path.win32.join('/apps', 'folder')));   // what runs on Windows today
console.log(encodeURI(path.posix.join('/apps', 'folder')));   // the fix
"
%5Capps%5Cfolder
/apps/folder
```
The first line matches the issue's reported output byte-for-byte.

**Added a regression test** (`src/test/suite/contentLoader.test.ts`) following this repo's own existing pattern exactly (`ContentLoader` construction + `fsReadDir`/`PathUtil.FileExistsStat` stubbing, same as `manager.test.ts`/`preview.test.ts`), asserting the generated index page contains working `/apps/folder/`-style links and no `%5C`.

**What I could and couldn't run in my environment:** `npm run compile` (`tsc -p ./`) succeeds clean, and `eslint` on both changed files is clean. I could not run the full suite (`xvfb-run -a npm test`, per your CI config) — no display server available in my environment and no way to install one without root. I want to be upfront about that rather than claim a green test run I didn't get, but wanted to flag that the standalone reproduction above uses the exact same `path` module logic the fix and test exercise, so I'm confident in the fix's correctness even without the full Electron-hosted suite run.

