### PR TITLE
Fix live preview breaking on # in file or folder names

### DIFF
--- a/src/test/suite/pathUtil.test.ts
+++ b/src/test/suite/pathUtil.test.ts
@@ -122,6 +122,24 @@ describe('GetWorkspaceFromRelativePath / GetWorkspaceFromAbsolutePath', () => {
 	});
 });
 
+describe('EscapePathParts / UnescapePathParts', () => {
+	it('escapes # in a path segment so it is not treated as a URL fragment delimiter', () => {
+		const actual = PathUtil.EscapePathParts('my#folder/index.html');
+		assert.strictEqual(actual, 'my%23folder/index.html');
+	});
+
+	it('round-trips a path segment containing #', () => {
+		const escaped = PathUtil.EscapePathParts('my#folder/index.html');
+		const actual = PathUtil.UnescapePathParts(escaped);
+		assert.strictEqual(actual, 'my#folder/index.html');
+	});
+
+	it('escapes a leading # the same as one in the middle of a segment', () => {
+		const actual = PathUtil.EscapePathParts('#folder/index.html');
+		assert.strictEqual(actual, '%23folder/index.html');
+	});
+});
+
 describe('getEndpointParent', () => {
 	it('returns the correct endpoint parent for full paths', async () => {
 		const endpoint1 = PathUtil.GetEndpointParent('c:/Users/TestUser/workspace1/');

--- a/src/utils/pathUtil.ts
+++ b/src/utils/pathUtil.ts
@@ -26,7 +26,7 @@ export class PathUtil {
 
 		const newParts = parts
 			.filter((part) => part.length > 0)
-			.map((filterdPart) => encodeURI(filterdPart));
+			.map((filterdPart) => encodeURIComponent(filterdPart));
 		return newParts.join('/');
 	}
 
@@ -39,7 +39,7 @@ export class PathUtil {
 		const parts = file.split('/');
 		const newParts = parts
 			.filter((part) => part.length > 0)
-			.map((filterdPart) => decodeURI(filterdPart));
+			.map((filterdPart) => decodeURIComponent(filterdPart));
 		return newParts.join('/');
 	}
 


### PR DESCRIPTION
## Bug

`PathUtil.EscapePathParts` escapes each path segment with `encodeURI`, which deliberately leaves `#` (and a few other reserved characters like `?`, `&`) unescaped — it's designed for encoding a full URI, where those characters are structural delimiters, not for encoding an individual path segment.

A file or folder name containing `#` therefore produces a preview URL where the browser treats everything from `#` onward as a fragment and never sends it to the server, so the file isn't found — the server falls back to showing the parent directory listing instead.

## Fix

Switched `EscapePathParts`/`UnescapePathParts` to `encodeURIComponent`/`decodeURIComponent`, which escape (and correctly reverse) all reserved characters in a path segment rather than only some of them.

## Verification

`EscapePathParts`/`UnescapePathParts` don't touch the VS Code API directly, so I could reproduce the exact old vs. new behavior standalone with Node's own `encodeURI`/`encodeURIComponent`:

```
--- old (buggy) ---
escapeOld('#folder/index.html') -> '#folder/index.html'   // # survives, browser truncates here
--- new (fixed) ---
escapeNew('#folder/index.html') -> '%23folder/index.html'
unescapeNew(that)                -> '#folder/index.html'  // round-trips correctly
```

Added 3 regression tests to `src/test/suite/pathUtil.test.ts` following the existing file's `describe`/`it` pattern, covering escape, round-trip, and a leading `#`. `tsc -p ./` and `eslint src` are both clean. I wasn't able to run the full Electron-based extension-host test suite in this environment (no `Xvfb`, and installing one needs root here), so I'm disclosing that rather than claiming it — the new tests are pure (no `vscode.*` calls, matching the neighboring `getEndpointParent` tests in the same file) so they should run cleanly in CI.

Fixes #750