### PR TITLE
Use the forwarded address for integrated browser previews

### DIFF
--- a/src/editorPreview/previewManager.ts
+++ b/src/editorPreview/previewManager.ts
@@ -67,7 +67,14 @@ export class PreviewManager extends Disposable {
 
 		// Check if we should use the integrated browser instead
 		if (await SettingUtil.shouldUseIntegratedBrowser()) {
-			const url = `http://${connection.host}:${connection.httpPort}${path}?vscode-livepreview=true`;
+			const externalUri = await connection.resolveExternalHTTPUri();
+			const query = new URLSearchParams(externalUri.query);
+			query.set('vscode-livepreview', 'true');
+			const url = vscode.Uri.joinPath(externalUri, path)
+				.with({
+					query: query.toString(),
+				})
+				.toString(true);
 			await vscode.commands.executeCommand(INTEGRATED_BROWSER_COMMAND, {
 				url,
 				openToSide: true,

--- a/src/test/suite/preview.test.ts
+++ b/src/test/suite/preview.test.ts
@@ -14,6 +14,7 @@ import { makeSetting, testWorkspaces } from './common';
 import { Connection } from '../../connectionInfo/connection';
 import { WebviewComm } from '../../editorPreview/webviewComm';
 import { ExternalBrowserUtils } from '../../utils/externalBrowserUtils';
+import { INTEGRATED_BROWSER_COMMAND } from '../../utils/constants';
 
 describe('PreviewManager', () => {
 	let sandbox: sinon.SinonSandbox;
@@ -74,6 +75,39 @@ describe('PreviewManager', () => {
 		assert.ok(goToFile.getCall(1).calledWith('/index.html', true));
 		assert.ok(goToFile.getCall(2).calledWith('/index.html', true));
 		assert.ok(goToFile.getCall(3).calledWith('/page.html', true));
+	});
+
+	it('uses the forwarded address in the integrated browser', async () => {
+		const shouldUseIntegratedBrowser = sinon
+			.stub(SettingUtil, 'shouldUseIntegratedBrowser')
+			.resolves(true);
+		const resolveExternalHTTPUri = sinon
+			.stub(connection, 'resolveExternalHTTPUri')
+			.resolves(
+				vscode.Uri.parse('https://forwarded.example.dev/base/?token=secret')
+			);
+		const executeCommand = sinon.stub(vscode.commands, 'executeCommand');
+
+		try {
+			await previewManager.launchFileInEmbeddedPreview(
+				undefined,
+				connection,
+				vscode.Uri.joinPath(testWorkspaces[0].uri, '/index.html')
+			);
+
+			assert.ok(resolveExternalHTTPUri.calledOnce);
+			assert.ok(
+				executeCommand.calledOnceWith(INTEGRATED_BROWSER_COMMAND, {
+					url: 'https://forwarded.example.dev/base/index.html?token=secret&vscode-livepreview=true',
+					openToSide: true,
+					reuseUrlFilter: '**?vscode-livepreview=true',
+				})
+			);
+		} finally {
+			executeCommand.restore();
+			resolveExternalHTTPUri.restore();
+			shouldUseIntegratedBrowser.restore();
+		}
 	});
 
 	it("previews in external preview (non-debug)", async () => {


### PR DESCRIPTION
Fixes #817

## Problem

When Live Preview runs in a Dev Container, the server may listen on remote port 3000 while VS Code forwards it to a different local port. If local port 3000 is unavailable, VS Code may forward the server to localhost:3001, but the integrated preview previously continued to open localhost:3000 and failed to connect.

## Changes

- Resolve the HTTP URI through vscode.env.asExternalUri before opening the integrated browser.
- Preserve paths and query parameters from the forwarded URI.
- Add regression coverage to verify that the integrated browser receives the resolved address.

## Expected behavior

The integrated browser now follows the Forwarded Address selected by VS Code. For example, when remote port 3000 is forwarded to local port 3001, the preview opens through localhost:3001 while retaining the Live Preview browser reuse marker.

## Validation

- npm run compile
- npm run lint
- Full extension test suite: 53 passing
- Fork GitHub Actions: Compile and Test passed